### PR TITLE
Fix så henting av featuretoggles også fungerer når bruker ikke er innlogget

### DIFF
--- a/src/main/kotlin/no/nav/klage/oppgave/api/FeatureToggleController.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/FeatureToggleController.kt
@@ -3,12 +3,18 @@ package no.nav.klage.oppgave.api
 import no.finn.unleash.Unleash
 import no.finn.unleash.UnleashContext
 import no.nav.klage.oppgave.service.unleash.TokenUtils
+import no.nav.klage.oppgave.util.getLogger
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
 class FeatureToggleController(private val unleash: Unleash, private val tokenUtils: TokenUtils) {
+
+    companion object {
+        @Suppress("JAVA_CLASS_ON_COMPANION")
+        private val logger = getLogger(javaClass.enclosingClass)
+    }
 
     @GetMapping("/featuretoggle/{toggleName}")
     fun getToggle(@PathVariable("toggleName") toggleName: String): Boolean =
@@ -18,6 +24,13 @@ class FeatureToggleController(private val unleash: Unleash, private val tokenUti
         unleash.isEnabled(feature, contextMedInnloggetBruker())
 
     private fun contextMedInnloggetBruker(): UnleashContext? =
-        UnleashContext.builder().userId(tokenUtils.getInnloggetIdent()).build()
-    
+        UnleashContext.builder().userId(getIdent()).build()
+
+    private fun getIdent() = try {
+        tokenUtils.getInnloggetIdent()
+    } catch (e: Exception) {
+        logger.info("Not able to retrieve token", e)
+        "UINNLOGGET"
+    }
+
 }


### PR DESCRIPTION
Lagt på en try-catch rundt henting av ident, returnerer UINNLOGGET hvis det ikke er en innlogget bruker. Jeg er ikke 100% sikker på denne her, men antar at det gir mening å kunne ha toggles også kun per miljø, og da uten å måtte ha en innlogget bruker. Så jeg tror det er lurt. :) 