### PR TITLE
Assign saksbehandler til Oppgave

### DIFF
--- a/src/main/kotlin/no/nav/klage/oppgave/api/OppgaveController.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/OppgaveController.kt
@@ -59,6 +59,16 @@ class OppgaveController(val oppgaveService: OppgaveService) {
         return ResponseEntity.ok().location(uri).body(oppgave)
     }
 
+    @PutMapping("/oppgaver/{id}/saksbehandler")
+    fun setAssignedSaksbehandler(@PathVariable("id") oppgaveId: Int, @RequestBody ident: String): ResponseEntity<OppgaveView> {
+        logger.debug("setAssignedSaksbehandler is requested")
+        val oppgave = oppgaveService.assignOppgave(oppgaveId, ident)
+        val uri = MvcUriComponentsBuilder
+            .fromMethodName(OppgaveController::class.java, "getOppgave", oppgaveId)
+            .buildAndExpand(oppgaveId).toUri()
+        return ResponseEntity.ok().location(uri).body(oppgave)
+    }
+
     @GetMapping("/oppgaver/randomhjemler")
     fun endreHjemlerAtRandomViolatingGetRpcStyleAndTotallyNotRestish(): List<OppgaveView> {
         logger.debug("endreHjemlerAtRandomViolatingGetRpcStyleAndTotallyNotRestish is requested")

--- a/src/main/kotlin/no/nav/klage/oppgave/clients/OppgaveClient.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/clients/OppgaveClient.kt
@@ -123,23 +123,10 @@ class OppgaveClient(
         return TEMA_SYK
     }
 
-    fun endreHjemmel(oppgaveId: Int, hjemmel: String): Oppgave {
-        var oppgave = oppgaveWebClient.get()
-            .uri { uriBuilder ->
-                uriBuilder.pathSegment("{id}").build(oppgaveId)
-            }
-            .header("Authorization", "Bearer ${stsClient.oidcToken()}")
-            .header("X-Correlation-ID", tracer.currentSpan().context().traceIdString())
-            .header("Nav-Consumer-Id", applicationName)
-            .retrieve()
-            .bodyToMono<EndreOppgave>()
-            .block() ?: throw RuntimeException("Oppgave could not be fetched")
-        logger.info("Endrer hjemmel for oppgave {} fra {} til {}", oppgave.id, oppgave.metadata?.get(HJEMMEL), hjemmel)
-        if (oppgave.metadata == null) {
-            oppgave.metadata = mutableMapOf()
-        }
-        oppgave.metadata!![HJEMMEL] = hjemmel
-
+    fun putOppgave(
+        oppgaveId: Int,
+        oppgave: EndreOppgave
+    ): Oppgave {
         return oppgaveWebClient.put()
             .uri { uriBuilder ->
                 uriBuilder.pathSegment("{id}").build(oppgaveId)
@@ -152,6 +139,19 @@ class OppgaveClient(
             .retrieve()
             .bodyToMono<Oppgave>()
             .block() ?: throw RuntimeException("Oppgave could not be put")
+    }
+
+    fun getOppgave(oppgaveId: Int): Oppgave {
+        return oppgaveWebClient.get()
+            .uri { uriBuilder ->
+                uriBuilder.pathSegment("{id}").build(oppgaveId)
+            }
+            .header("Authorization", "Bearer ${stsClient.oidcToken()}")
+            .header("X-Correlation-ID", tracer.currentSpan().context().traceIdString())
+            .header("Nav-Consumer-Id", applicationName)
+            .retrieve()
+            .bodyToMono<Oppgave>()
+            .block() ?: throw RuntimeException("Oppgave could not be fetched")
     }
 
 }

--- a/src/main/kotlin/no/nav/klage/oppgave/domain/gosys/Oppgave.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/domain/gosys/Oppgave.kt
@@ -98,7 +98,7 @@ data class EndreOppgave(
     val mappeId: Long? = null,
     val prioritet: Prioritet? = null,
     val status: Status? = null,
-    var metadata: MutableMap<String, String>?,
+    var metadata: MutableMap<String, String>? = null,
     val fristFerdigstillelse: LocalDate?,
     val aktivDato: String? = null
 )

--- a/src/main/kotlin/no/nav/klage/oppgave/domain/gosys/Oppgave.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/domain/gosys/Oppgave.kt
@@ -43,8 +43,38 @@ data class Oppgave(
     val opprettetTidspunkt: String? = null,
     val ferdigstiltTidspunkt: String? = null,
     val endretTidspunkt: String? = null
-)
+) {
+    fun toEndreOppgave() = EndreOppgave(
+        id = id,
+        tildeltEnhetsnr = tildeltEnhetsnr,
+        endretAvEnhetsnr = endretAvEnhetsnr,
+        journalpostId = journalpostId,
+        journalpostkilde = journalpostkilde,
+        behandlesAvApplikasjon = behandlesAvApplikasjon,
+        saksreferanse = saksreferanse,
+        bnr = bnr,
+        samhandlernr = samhandlernr,
+        aktoerId = aktoerId,
+        orgnr = orgnr,
+        tilordnetRessurs = tilordnetRessurs,
+        beskrivelse = beskrivelse,
+        temagruppe = temagruppe,
+        tema = tema,
+        behandlingstema = behandlingstema,
+        oppgavetype = oppgavetype,
+        behandlingstype = behandlingstype,
+        versjon = versjon,
+        mappeId = mappeId,
+        prioritet = prioritet,
+        status = status,
+        metadata = metadata?.toMutableMap(),
+        fristFerdigstillelse = fristFerdigstillelse,
+        aktivDato = aktivDato
+    )
 
+}
+
+// De feltene som skal kunne endres må gjøres mutable/defineres som var isf val
 data class EndreOppgave(
     val id: Int,
     val tildeltEnhetsnr: String? = null,
@@ -57,7 +87,7 @@ data class EndreOppgave(
     val samhandlernr: String? = null,
     val aktoerId: String? = null,
     val orgnr: String? = null,
-    val tilordnetRessurs: String? = null,
+    var tilordnetRessurs: String? = null,
     val beskrivelse: String? = null,
     val temagruppe: String? = null,
     val tema: String,
@@ -68,7 +98,7 @@ data class EndreOppgave(
     val mappeId: Long? = null,
     val prioritet: Prioritet? = null,
     val status: Status? = null,
-    var metadata: MutableMap<String, String>? = null,
+    var metadata: MutableMap<String, String>?,
     val fristFerdigstillelse: LocalDate?,
     val aktivDato: String? = null
 )

--- a/src/main/kotlin/no/nav/klage/oppgave/domain/view/OppgaveView.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/domain/view/OppgaveView.kt
@@ -11,7 +11,7 @@ data class OppgaveView(
     val bruker: Bruker,
     val type: String,
     val ytelse: String,
-    val hjemmel: List<String>,
+    val hjemmel: String,
     val frist: LocalDate?,
     val saksbehandler: Saksbehandler? = null
 ) {

--- a/src/main/kotlin/no/nav/klage/oppgave/service/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/service/OppgaveService.kt
@@ -162,7 +162,7 @@ class OppgaveService(
     }
 
     fun assignOppgave(oppgaveId: Int, saksbehandlerIdent: String?): OppgaveView {
-        var oppgave = oppgaveClient.getOppgave(oppgaveId).toEndreOppgave()
+        val oppgave = oppgaveClient.getOppgave(oppgaveId).toEndreOppgave()
         logger.info("Endrer tilordnetRessurs for oppgave {} fra {} til {}", oppgave.id, oppgave.tilordnetRessurs, saksbehandlerIdent)
         oppgave.tilordnetRessurs = saksbehandlerIdent
 

--- a/src/test/kotlin/no/nav/klage/oppgave/service/OppgaveServiceTest.kt
+++ b/src/test/kotlin/no/nav/klage/oppgave/service/OppgaveServiceTest.kt
@@ -39,13 +39,13 @@ internal class OppgaveServiceTest {
     fun `hjemmel is set correctly`() {
         val hjemmel = "8-1"
         val oppgaveService = oppgaveServiceWithHjemmel(hjemmel)
-        assertThat(oppgaveService.getOppgaver().first().hjemmel.first()).isEqualTo(hjemmel)
+        assertThat(oppgaveService.getOppgaver().first().hjemmel).isEqualTo(hjemmel)
     }
 
     @Test
     fun `missing hjemmel does not fail`() {
         val oppgaveService = oppgaveServiceWithType("something")
-        assertThat(oppgaveService.getOppgaver().first().hjemmel.first()).isEqualTo("mangler")
+        assertThat(oppgaveService.getOppgaver().first().hjemmel).isEqualTo("mangler")
     }
 
     @Test


### PR DESCRIPTION

Her har jeg gjort en litt klassisk Hågen-tabbe, og tatt litt for mye med inn i PRen.. Det er egentlig tre ting her, jeg har gjort om hjemmel fra å være List<String> til å være String, jeg har refaktorert litt eksisterende kode, og jeg har lagt til kode for å assigne en saksbehandler til en oppgave.

Jeg hadde tenkt til å se om jeg kunne dele det opp i tre PRer i stedet for en, men så så jeg at frontend-endringen som matcher hjemmel-endringen allerede var dyttet ut, så da tenkte jeg at det var greit å få det ut..