### PR TITLE
Lagt til håndtering av WebClientResponseException 

### DIFF
--- a/src/main/kotlin/no/nav/klage/oppgave/config/problem/ProblemHandlingControllerAdvice.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/config/problem/ProblemHandlingControllerAdvice.kt
@@ -2,19 +2,27 @@ package no.nav.klage.oppgave.config.problem
 
 import no.nav.klage.oppgave.exceptions.OppgaveIdWrongFormatException
 import no.nav.klage.oppgave.exceptions.OppgaveNotFoundException
+import no.nav.klage.oppgave.util.getLogger
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.context.request.NativeWebRequest
+import org.springframework.web.reactive.function.client.WebClientResponseException
 import org.zalando.problem.Problem
 import org.zalando.problem.Status
 import org.zalando.problem.spring.web.advice.AdviceTrait
 import org.zalando.problem.spring.web.advice.ProblemHandling
 
 @ControllerAdvice
-class ProblemHandlingControllerAdvice : OppgaveNotFoundExceptionAdviceTrait, ProblemHandling
+class ProblemHandlingControllerAdvice : OurOwnExceptionAdviceTrait, ProblemHandling
 
-interface OppgaveNotFoundExceptionAdviceTrait : AdviceTrait {
+interface OurOwnExceptionAdviceTrait : AdviceTrait {
+
+    companion object {
+        @Suppress("JAVA_CLASS_ON_COMPANION")
+        private val logger = getLogger(javaClass.enclosingClass)
+    }
 
     @ExceptionHandler
     fun handleOppgaveNotFound(ex: OppgaveNotFoundException, request: NativeWebRequest): ResponseEntity<Problem> =
@@ -24,4 +32,24 @@ interface OppgaveNotFoundExceptionAdviceTrait : AdviceTrait {
     fun handleOppgaveIdNotParsable(ex: OppgaveIdWrongFormatException, request: NativeWebRequest): ResponseEntity<Problem> =
         create(Status.BAD_REQUEST, ex, request)
 
+    @ExceptionHandler
+    fun handleResponseStatusException(
+        ex: WebClientResponseException,
+        request: NativeWebRequest
+    ): ResponseEntity<Problem> =
+        create(
+            ex, Problem.builder()
+                .withStatus(mapStatus(ex.statusCode))
+                .withTitle(ex.statusText)
+                .withDetail(ex.responseBodyAsString)
+                .build(), request
+        )
+
+    fun mapStatus(status: HttpStatus): Status =
+        try {
+            Status.valueOf(status.value())
+        } catch (ex: Exception) {
+            logger.warn("Unable to map WebClientResponseException with status {}", status.value())
+            Status.INTERNAL_SERVER_ERROR
+        }
 }

--- a/src/test/kotlin/no/nav/klage/oppgave/api/ProblemHandlingTest.kt
+++ b/src/test/kotlin/no/nav/klage/oppgave/api/ProblemHandlingTest.kt
@@ -1,0 +1,54 @@
+package no.nav.klage.oppgave.api
+
+import com.ninjasquad.springmockk.MockkBean
+import io.mockk.every
+import no.finn.unleash.Unleash
+import no.finn.unleash.UnleashContext
+import no.nav.klage.oppgave.repositories.InnloggetSaksbehandlerRepository
+import org.hamcrest.Matchers.containsString
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers.print
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.*
+import org.springframework.web.reactive.function.client.WebClientResponseException
+import org.zalando.problem.spring.web.autoconfigure.ProblemAutoConfiguration
+import org.zalando.problem.spring.web.autoconfigure.ProblemJacksonAutoConfiguration
+import org.zalando.problem.spring.web.autoconfigure.ProblemJacksonWebMvcAutoConfiguration
+
+@WebMvcTest(FeatureToggleController::class)
+@ImportAutoConfiguration( classes= [
+    ProblemJacksonWebMvcAutoConfiguration::class,
+    ProblemJacksonAutoConfiguration::class,
+    ProblemAutoConfiguration::class ])
+@ActiveProfiles("local")
+class ProblemHandlingTest() {
+
+    @Autowired
+    lateinit var mockMvc: MockMvc
+
+    @MockkBean
+    lateinit var unleash: Unleash
+
+    @MockkBean
+    lateinit var innloggetSaksbehandlerRepository: InnloggetSaksbehandlerRepository
+
+    @BeforeEach
+    fun setup() {
+        every { unleash.isEnabled(any(), any<UnleashContext>()) } throws WebClientResponseException.create( HttpStatus.CONFLICT.value(),HttpStatus.CONFLICT.reasonPhrase, HttpHeaders(), "{ \"error\": \"min tekst\" }".toByteArray(Charsets.UTF_8), null, null)
+    }
+
+    @Test
+    fun `open toggle should return true`() {
+        this.mockMvc.perform(get("/aapenfeaturetoggle/testing")).andDo(print()).andExpect(status().isConflict())
+            .andExpect(content().string(containsString("{\"title\":\"Conflict\",\"status\":409,\"detail\":\"{ \\\"error\\\": \\\"min tekst\\\" }\"}")))
+    }
+
+}


### PR DESCRIPTION
…så de mappes slik at vi returnerer samme statuskode til frontend som klienten vår gjorde til oss