### PR TITLE
Always include enhetsnr in queries.

### DIFF
--- a/src/main/kotlin/no/nav/klage/oppgave/domain/OppgaverSearchCriteria.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/domain/OppgaverSearchCriteria.kt
@@ -8,7 +8,8 @@ data class OppgaverSearchCriteria(
     val order: Order? = null,
     val offset: Int,
     val limit: Int,
-    val saksbehandler: String? = null
+    val saksbehandler: String? = null,
+    var enhetsnr: String? = null
 ) {
     enum class Order {
         ASC, DESC

--- a/src/main/kotlin/no/nav/klage/oppgave/domain/gosys/Oppgave.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/domain/gosys/Oppgave.kt
@@ -3,7 +3,10 @@ package no.nav.klage.oppgave.domain.gosys
 import java.time.LocalDate
 
 const val BEHANDLINGSTYPE_KLAGE = "ae0058"
-const val BEHANDLINGSTYPE_FEILUTBETALING = "ae0161"
+const val BEHANDLINGSTYPE_ANKE = "ae0046"
+
+const val TEMA_SYK = "SYK"
+const val TEMA_FOR = "FOR"
 
 data class OppgaveResponse(
     val antallTreffTotalt: Int,

--- a/src/main/kotlin/no/nav/klage/oppgave/domain/view/OppgaveView.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/domain/view/OppgaveView.kt
@@ -3,8 +3,10 @@ package no.nav.klage.oppgave.domain.view
 import java.time.LocalDate
 
 const val HJEMMEL = "HJEMMEL"
-const val TYPE_KLAGE = "klage"
-const val TYPE_FEILUTBETALING = "feilutbetaling"
+const val TYPE_KLAGE = "Klage"
+const val TYPE_ANKE = "Anke"
+const val YTELSE_SYK = "Sykepenger"
+const val YTELSE_FOR = "Foreldrepenger"
 
 data class TildelteOppgaverRespons(
     val antallTreffTotalt: Int,

--- a/src/main/kotlin/no/nav/klage/oppgave/service/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/service/OppgaveService.kt
@@ -3,15 +3,13 @@ package no.nav.klage.oppgave.service
 import no.nav.klage.oppgave.clients.OppgaveClient
 import no.nav.klage.oppgave.clients.PdlClient
 import no.nav.klage.oppgave.domain.OppgaverSearchCriteria
-import no.nav.klage.oppgave.domain.gosys.BEHANDLINGSTYPE_FEILUTBETALING
-import no.nav.klage.oppgave.domain.gosys.BEHANDLINGSTYPE_KLAGE
+import no.nav.klage.oppgave.domain.gosys.*
 import no.nav.klage.oppgave.domain.gosys.Gruppe.FOLKEREGISTERIDENT
-import no.nav.klage.oppgave.domain.gosys.Oppgave
-import no.nav.klage.oppgave.domain.gosys.OppgaveResponse
 import no.nav.klage.oppgave.domain.pdl.Navn
 import no.nav.klage.oppgave.domain.view.*
 import no.nav.klage.oppgave.exceptions.NotMatchingUserException
 import no.nav.klage.oppgave.repositories.InnloggetSaksbehandlerRepository
+import no.nav.klage.oppgave.repositories.SaksbehandlerRepository
 import no.nav.klage.oppgave.util.getLogger
 import org.springframework.stereotype.Service
 
@@ -20,7 +18,8 @@ import org.springframework.stereotype.Service
 class OppgaveService(
     val oppgaveClient: OppgaveClient,
     val pdlClient: PdlClient,
-    val innloggetSaksbehandlerRepository: InnloggetSaksbehandlerRepository
+    val innloggetSaksbehandlerRepository: InnloggetSaksbehandlerRepository,
+    val saksbehandlerRepository: SaksbehandlerRepository
 ) {
 
     companion object {
@@ -37,6 +36,8 @@ class OppgaveService(
             throw NotMatchingUserException("logged in user does not match sent in user. Logged in: $innloggetIdent, sent in: $navIdent")
         }
 
+        oppgaverSearchCriteria.enrichWithEnhetsnrForLoggedInUser(innloggetIdent)
+
         val oppgaveResponse = oppgaveClient.getOneSearchPage(oppgaverSearchCriteria)
         return TildelteOppgaverRespons(
             antallTreffTotalt = oppgaveResponse.antallTreffTotalt,
@@ -45,11 +46,18 @@ class OppgaveService(
     }
 
     fun searchIkkeTildelteOppgaver(oppgaverSearchCriteria: OppgaverSearchCriteria): IkkeTildelteOppgaverRespons {
+        oppgaverSearchCriteria.enrichWithEnhetsnrForLoggedInUser(innloggetSaksbehandlerRepository.getInnloggetIdent())
+
         val oppgaveResponse = oppgaveClient.getOneSearchPage(oppgaverSearchCriteria)
         return IkkeTildelteOppgaverRespons(
             antallTreffTotalt = oppgaveResponse.antallTreffTotalt,
             oppgaver = oppgaveResponse.toIkkeTildelteOppgaverView()
         )
+    }
+
+    private fun OppgaverSearchCriteria.enrichWithEnhetsnrForLoggedInUser(innloggetIdent: String) {
+        val tilgangerForSaksbehandler = saksbehandlerRepository.getTilgangerForSaksbehandler(innloggetIdent)
+        this.enhetsnr = tilgangerForSaksbehandler.enheter.first().enhetId
     }
 
     private fun OppgaveResponse.toTildelteOppgaverView(): List<TildeltOppgave> {
@@ -60,7 +68,7 @@ class OppgaveService(
                 id = oppgave.id.toString(),
                 bruker = brukere[oppgave.getFnrForBruker()] ?: TildeltOppgave.Bruker("Mangler fnr", "Mangler fnr"),
                 type = oppgave.toType(),
-                ytelse = oppgave.tema,
+                ytelse = oppgave.toYtelse(),
                 hjemmel = oppgave.metadata.toHjemmel(),
                 frist = oppgave.fristFerdigstillelse,
                 versjon = oppgave.versjon
@@ -73,7 +81,7 @@ class OppgaveService(
             IkkeTildeltOppgave(
                 id = oppgave.id.toString(),
                 type = oppgave.toType(),
-                ytelse = oppgave.tema,
+                ytelse = oppgave.toYtelse(),
                 hjemmel = oppgave.metadata.toHjemmel(),
                 frist = oppgave.fristFerdigstillelse,
                 versjon = oppgave.versjon
@@ -105,10 +113,16 @@ class OppgaveService(
         return if (behandlingstema == null) {
             when (behandlingstype) {
                 BEHANDLINGSTYPE_KLAGE -> TYPE_KLAGE
-                BEHANDLINGSTYPE_FEILUTBETALING -> TYPE_FEILUTBETALING
-                else -> "mangler"
+                BEHANDLINGSTYPE_ANKE -> TYPE_ANKE
+                else -> "ukjent"
             }
         } else "mangler"
+    }
+
+    private fun Oppgave.toYtelse(): String = when (tema) {
+        TEMA_SYK -> YTELSE_SYK
+        TEMA_FOR -> YTELSE_FOR
+        else -> tema
     }
 
     private fun Oppgave.getFnrForBruker() = identer?.find { i -> i.gruppe == FOLKEREGISTERIDENT }?.ident

--- a/src/main/kotlin/no/nav/klage/oppgave/service/OppgaveService.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/service/OppgaveService.kt
@@ -57,6 +57,9 @@ class OppgaveService(
 
     private fun OppgaverSearchCriteria.enrichWithEnhetsnrForLoggedInUser(innloggetIdent: String) {
         val tilgangerForSaksbehandler = saksbehandlerRepository.getTilgangerForSaksbehandler(innloggetIdent)
+        if (tilgangerForSaksbehandler.enheter.size > 1) {
+            logger.warn("Saksbehandler ({}) had more than one enhet. Only using the first.", innloggetIdent)
+        }
         this.enhetsnr = tilgangerForSaksbehandler.enheter.first().enhetId
     }
 


### PR DESCRIPTION
Alltid bruk enhetsnr ved søk. Søk inkluderer klage/anke hvis inget annet angitt.

På sikt må vi finne ut om vi kan håndtere disse kodeverkstrengene litt penere.

Ikke merge før url til axsys i api-gw er lagt inn.