### PR TITLE
Use same strategy as oppgave to parse datetime

### DIFF
--- a/src/main/kotlin/no/nav/klage/oppgave/api/internal/OffsetDateTimeToLocalDateTimeDeserializer.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/internal/OffsetDateTimeToLocalDateTimeDeserializer.kt
@@ -1,0 +1,15 @@
+package no.nav.klage.oppgave.api.internal
+
+import com.fasterxml.jackson.core.JsonParser
+import com.fasterxml.jackson.databind.DeserializationContext
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+class OffsetDateTimeToLocalDateTimeDeserializer : StdDeserializer<LocalDateTime>(LocalDateTime::class.java) {
+
+    override fun deserialize(jsonParser: JsonParser, ctxt: DeserializationContext?): LocalDateTime {
+        return LocalDateTime.parse(jsonParser.readValueAs(String::class.java), DateTimeFormatter.ISO_OFFSET_DATE_TIME)
+    }
+
+}

--- a/src/main/kotlin/no/nav/klage/oppgave/api/internal/OppgaveKopiAPIModel.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/internal/OppgaveKopiAPIModel.kt
@@ -1,6 +1,6 @@
 package no.nav.klage.oppgave.api.internal
 
-import com.fasterxml.jackson.annotation.JsonFormat
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize
 import java.time.LocalDate
 import java.time.LocalDateTime
 
@@ -27,11 +27,11 @@ data class OppgaveKopiAPIModel(
     val aktivDato: LocalDate,
     val opprettetAv: String,
     val endretAv: String? = null,
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
+    @JsonDeserialize(using = OffsetDateTimeToLocalDateTimeDeserializer::class)
     val opprettetTidspunkt: LocalDateTime,
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
+    @JsonDeserialize(using = OffsetDateTimeToLocalDateTimeDeserializer::class)
     val endretTidspunkt: LocalDateTime? = null,
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSXXX")
+    @JsonDeserialize(using = OffsetDateTimeToLocalDateTimeDeserializer::class)
     val ferdigstiltTidspunkt: LocalDateTime? = null,
     val behandlesAvApplikasjon: String? = null,
     val journalpostkilde: String? = null,


### PR DESCRIPTION
They make a LocalDateTime into an OffsetDateTime when serializing to JSON (and back when deserializing). The offset part can be ignored as we only care about local time.