### PR TITLE
Lagt til endepunkt for å slette en kobling mellom en klagebehandling og en journalpost

### DIFF
--- a/src/main/kotlin/no/nav/klage/oppgave/api/DokumentController.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/DokumentController.kt
@@ -75,12 +75,12 @@ class DokumentController(
         value = "Fjerner et dokument fra en klagebehandling",
         notes = "Sletter knytningen mellom en journalpost fra SAF og klagebehandlingen den har vært knyttet til."
     )
-    @DeleteMapping("/klagebehandlinger/{behandlingsid}/dokumenter/{journalpostId}", produces = ["application/json"])
+    @DeleteMapping("/klagebehandlinger/{behandlingsid}/dokumenter/{journalpostid}", produces = ["application/json"])
     @ResponseStatus(HttpStatus.NO_CONTENT)
     fun deconnectDokument(
         @ApiParam(value = "Id til klagebehandlingen i vårt system")
         @PathVariable behandlingsid: String,
-        @PathVariable journalpostId: String
+        @PathVariable(name = "journalpostid") journalpostId: String
     ) {
         val klagebehandlingId = UUID.fromString(behandlingsid)
         dokumentService.deconnectJournalpostFromKlagebehandling(klagebehandlingId, journalpostId)

--- a/src/main/kotlin/no/nav/klage/oppgave/api/DokumentController.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/DokumentController.kt
@@ -4,6 +4,7 @@ import io.swagger.annotations.Api
 import io.swagger.annotations.ApiOperation
 import io.swagger.annotations.ApiParam
 import no.nav.klage.oppgave.api.view.DokumentKnytning
+import no.nav.klage.oppgave.api.view.DokumentReferanserResponse
 import no.nav.klage.oppgave.api.view.DokumenterResponse
 import no.nav.klage.oppgave.config.SecurityConfiguration.Companion.ISSUER_AAD
 import no.nav.klage.oppgave.service.DokumentService
@@ -50,7 +51,39 @@ class DokumentController(
         @PathVariable behandlingsid: String
     ): DokumenterResponse {
         val klagebehandlingId = UUID.fromString(behandlingsid)
-        return dokumentService.fetchDokumenterConnectedToKlagebehandling(klagebehandlingId)
+        return dokumentService.fetchJournalposterConnectedToKlagebehandling(klagebehandlingId)
+    }
+
+    @ApiOperation(
+        value = "Hent IDene til dokumentene knyttet til en klagebehandling",
+        notes = "Henter IDene til dokumentene som saksbehandler har markert at skal knyttes til klagebehandlingen."
+    )
+    @GetMapping("/klagebehandlinger/{behandlingsid}/tilknyttededokumenter", produces = ["application/json"])
+    fun fetchConnectedDokumentIder(
+        @ApiParam(value = "Id til klagebehandlingen i vårt system")
+        @PathVariable behandlingsid: String
+    ): DokumentReferanserResponse {
+        val klagebehandlingId = UUID.fromString(behandlingsid)
+        return DokumentReferanserResponse(
+            dokumentService.fetchJournalpostIderConnectedToKlagebehandling(
+                klagebehandlingId
+            )
+        )
+    }
+
+    @ApiOperation(
+        value = "Fjerner et dokument fra en klagebehandling",
+        notes = "Sletter knytningen mellom en journalpost fra SAF og klagebehandlingen den har vært knyttet til."
+    )
+    @DeleteMapping("/klagebehandlinger/{behandlingsid}/dokumenter/{journalpostId}", produces = ["application/json"])
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    fun deconnectDokument(
+        @ApiParam(value = "Id til klagebehandlingen i vårt system")
+        @PathVariable behandlingsid: String,
+        @PathVariable journalpostId: String
+    ) {
+        val klagebehandlingId = UUID.fromString(behandlingsid)
+        dokumentService.deconnectJournalpostFromKlagebehandling(klagebehandlingId, journalpostId)
     }
 
     @ApiOperation(

--- a/src/main/kotlin/no/nav/klage/oppgave/api/DokumentController.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/DokumentController.kt
@@ -58,7 +58,7 @@ class DokumentController(
         value = "Hent IDene til dokumentene knyttet til en klagebehandling",
         notes = "Henter IDene til dokumentene som saksbehandler har markert at skal knyttes til klagebehandlingen."
     )
-    @GetMapping("/klagebehandlinger/{behandlingsid}/tilknyttededokumenter", produces = ["application/json"])
+    @GetMapping("/klagebehandlinger/{behandlingsid}/dokumentreferanser", produces = ["application/json"])
     fun fetchConnectedDokumentIder(
         @ApiParam(value = "Id til klagebehandlingen i vårt system")
         @PathVariable behandlingsid: String

--- a/src/main/kotlin/no/nav/klage/oppgave/api/mapper/DokumentMapper.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/mapper/DokumentMapper.kt
@@ -1,2 +1,0 @@
-package no.nav.klage.oppgave.api.mapper
-

--- a/src/main/kotlin/no/nav/klage/oppgave/api/view/DokumentView.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/view/DokumentView.kt
@@ -4,6 +4,8 @@ import java.time.LocalDate
 
 data class DokumenterResponse(val dokumenter: List<DokumentReferanse>, val pageReference: String? = null)
 
+data class DokumentReferanserResponse(val journalpostIder: List<String>)
+
 data class DokumentReferanse(
     val tittel: String,
     val beskrivelse: String,

--- a/src/main/kotlin/no/nav/klage/oppgave/repositories/SaksdokumentRepository.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/repositories/SaksdokumentRepository.kt
@@ -11,4 +11,6 @@ interface SaksdokumentRepository : JpaRepository<Saksdokument, UUID> {
     fun findByKlagebehandlingId(klagebehandlingId: UUID): List<Saksdokument>
 
     fun existsByKlagebehandlingIdAndReferanse(klagebehandlingId: UUID, referanse: String): Boolean
+
+    fun findByKlagebehandlingIdAndReferanse(klagebehandlingId: UUID, journalpostId: String): Saksdokument?
 }

--- a/src/main/kotlin/no/nav/klage/oppgave/service/DokumentService.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/service/DokumentService.kt
@@ -38,7 +38,10 @@ class DokumentService(
             safGraphQlClient.getDokumentoversiktBruker(klagebehandling.foedselsnummer, pageSize, previousPageRef)
         return DokumenterResponse(
             dokumenter = dokumentoversiktBruker.journalposter.map { journalpost ->
-                dokumentMapper.mapJournalpost(journalpost, valgteJournalpostIder.contains(journalpost.journalpostId))
+                dokumentMapper.mapJournalpost(
+                    journalpost,
+                    valgteJournalpostIder.contains(journalpost.journalpostId)
+                )
             },
             pageReference = if (dokumentoversiktBruker.sideInfo.finnesNesteSide) {
                 dokumentoversiktBruker.sideInfo.sluttpeker
@@ -48,7 +51,13 @@ class DokumentService(
         )
     }
 
-    fun fetchDokumenterConnectedToKlagebehandling(klagebehandlingId: UUID): DokumenterResponse {
+    fun fetchJournalpostIderConnectedToKlagebehandling(
+        klagebehandlingId: UUID
+    ): List<String> = saksdokumentRepository.findByKlagebehandlingId(klagebehandlingId).map { it.referanse }
+
+    fun fetchJournalposterConnectedToKlagebehandling(
+        klagebehandlingId: UUID
+    ): DokumenterResponse {
         val saksdokumenter = saksdokumentRepository.findByKlagebehandlingId(klagebehandlingId)
         return saksdokumenter
             .mapNotNull { safGraphQlClient.getJournalpost(it.referanse) }
@@ -57,10 +66,33 @@ class DokumentService(
     }
 
     fun connectJournalpostToKlagebehandling(klagebehandlingId: UUID, journalpostId: String) {
-        if (saksdokumentRepository.existsByKlagebehandlingIdAndReferanse(klagebehandlingId, journalpostId)) {
-            logger.debug("Journalpost $journalpostId is already connected to klagebehandling $klagebehandlingId, doing nothing")
-        } else {
-            saksdokumentRepository.save(Saksdokument(klagebehandlingId = klagebehandlingId, referanse = journalpostId))
+        try {
+            if (saksdokumentRepository.existsByKlagebehandlingIdAndReferanse(klagebehandlingId, journalpostId)) {
+                logger.debug("Journalpost $journalpostId is already connected to klagebehandling $klagebehandlingId, doing nothing")
+            } else {
+                saksdokumentRepository.save(
+                    Saksdokument(
+                        klagebehandlingId = klagebehandlingId,
+                        referanse = journalpostId
+                    )
+                )
+            }
+        } catch (e: Exception) {
+            logger.error("Error connecting $journalpostId to $klagebehandlingId", e)
+            throw e
+        }
+    }
+
+    fun deconnectJournalpostFromKlagebehandling(klagebehandlingId: UUID, journalpostId: String) {
+        try {
+            val saksdokument =
+                saksdokumentRepository.findByKlagebehandlingIdAndReferanse(klagebehandlingId, journalpostId)
+            if (saksdokument != null) {
+                saksdokumentRepository.delete(saksdokument)
+            }
+        } catch (e: Exception) {
+            logger.error("Error deconnecting $journalpostId from $klagebehandlingId", e)
+            throw e
         }
     }
 
@@ -74,24 +106,25 @@ class DokumentMapper {
     }
 
     //TODO: Har ikke tatt høyde for skjerming, ref https://confluence.adeo.no/pages/viewpage.action?pageId=320364687
-    fun mapJournalpost(journalpost: Journalpost, isConnected: Boolean) = DokumentReferanse(
-        tittel = journalpost.tittel ?: "journalposttittel mangler",
-        beskrivelse = journalpost.dokumenter?.map { dokumentinfo -> dokumentinfo.tittel }
-            ?.joinToString() ?: "tittel mangler",
-        beskrivelser = journalpost.dokumenter?.map { dokumentinfo -> dokumentinfo.tittel.nullAsTittelMangler() }
-            ?: emptyList(),
-        tema = journalpost.temanavn ?: "tema mangler",
-        registrert = journalpost.datoOpprettet.toLocalDate(),
-        dokumentInfoId = journalpost.dokumenter?.map { dokumentinfo -> dokumentinfo.dokumentInfoId }
-            ?.joinToString() ?: "-",
-        journalpostId = journalpost.journalpostId,
-        variantFormat = journalpost.dokumenter?.firstOrNull()?.dokumentvarianter?.map { dokumentvariant ->
-            logVariantFormat(
-                dokumentvariant
-            ); dokumentvariant.variantformat.name
-        }?.joinToString() ?: "-",
-        valgt = isConnected
-    )
+    fun mapJournalpost(journalpost: Journalpost, isConnected: Boolean) =
+        DokumentReferanse(
+            tittel = journalpost.tittel ?: "journalposttittel mangler",
+            beskrivelse = journalpost.dokumenter?.map { dokumentinfo -> dokumentinfo.tittel }
+                ?.joinToString() ?: "tittel mangler",
+            beskrivelser = journalpost.dokumenter?.map { dokumentinfo -> dokumentinfo.tittel.nullAsTittelMangler() }
+                ?: emptyList(),
+            tema = journalpost.temanavn ?: "tema mangler",
+            registrert = journalpost.datoOpprettet.toLocalDate(),
+            dokumentInfoId = journalpost.dokumenter?.map { dokumentinfo -> dokumentinfo.dokumentInfoId }
+                ?.joinToString() ?: "-",
+            journalpostId = journalpost.journalpostId,
+            variantFormat = journalpost.dokumenter?.firstOrNull()?.dokumentvarianter?.map { dokumentvariant ->
+                logVariantFormat(
+                    dokumentvariant
+                ); dokumentvariant.variantformat.name
+            }?.joinToString() ?: "-",
+            valgt = isConnected
+        )
 
     private fun String?.nullAsTittelMangler() = this ?: "tittel mangler"
 

--- a/src/main/kotlin/no/nav/klage/oppgave/service/DokumentService.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/service/DokumentService.kt
@@ -106,25 +106,24 @@ class DokumentMapper {
     }
 
     //TODO: Har ikke tatt høyde for skjerming, ref https://confluence.adeo.no/pages/viewpage.action?pageId=320364687
-    fun mapJournalpost(journalpost: Journalpost, isConnected: Boolean) =
-        DokumentReferanse(
-            tittel = journalpost.tittel ?: "journalposttittel mangler",
-            beskrivelse = journalpost.dokumenter?.map { dokumentinfo -> dokumentinfo.tittel }
-                ?.joinToString() ?: "tittel mangler",
-            beskrivelser = journalpost.dokumenter?.map { dokumentinfo -> dokumentinfo.tittel.nullAsTittelMangler() }
-                ?: emptyList(),
-            tema = journalpost.temanavn ?: "tema mangler",
-            registrert = journalpost.datoOpprettet.toLocalDate(),
-            dokumentInfoId = journalpost.dokumenter?.map { dokumentinfo -> dokumentinfo.dokumentInfoId }
-                ?.joinToString() ?: "-",
-            journalpostId = journalpost.journalpostId,
-            variantFormat = journalpost.dokumenter?.firstOrNull()?.dokumentvarianter?.map { dokumentvariant ->
-                logVariantFormat(
-                    dokumentvariant
-                ); dokumentvariant.variantformat.name
-            }?.joinToString() ?: "-",
-            valgt = isConnected
-        )
+    fun mapJournalpost(journalpost: Journalpost, isConnected: Boolean) = DokumentReferanse(
+        tittel = journalpost.tittel ?: "journalposttittel mangler",
+        beskrivelse = journalpost.dokumenter?.map { dokumentinfo -> dokumentinfo.tittel }
+            ?.joinToString() ?: "tittel mangler",
+        beskrivelser = journalpost.dokumenter?.map { dokumentinfo -> dokumentinfo.tittel.nullAsTittelMangler() }
+            ?: emptyList(),
+        tema = journalpost.temanavn ?: "tema mangler",
+        registrert = journalpost.datoOpprettet.toLocalDate(),
+        dokumentInfoId = journalpost.dokumenter?.map { dokumentinfo -> dokumentinfo.dokumentInfoId }
+            ?.joinToString() ?: "-",
+        journalpostId = journalpost.journalpostId,
+        variantFormat = journalpost.dokumenter?.firstOrNull()?.dokumentvarianter?.map { dokumentvariant ->
+            logVariantFormat(
+                dokumentvariant
+            ); dokumentvariant.variantformat.name
+        }?.joinToString() ?: "-",
+        valgt = isConnected
+    )
 
     private fun String?.nullAsTittelMangler() = this ?: "tittel mangler"
 


### PR DESCRIPTION
Samt lagt til et endepunkt for å returnere en skinny liste over tilkoblete journalposter.
Så nå kan Sven Anders vurdere hvilken approach han liker best.. 

Jeg innser at REST-biten av dette ikke henger helt på greip nå, iom at jeg tilbyr GET på både /klagebehandlinger/{behandlingsid}/dokumentreferanser og /klagebehandlinger/{behandlingsid}/dokumenter, men POST kun på /klagebehandlinger/{behandlingsid}/dokumenter og DELETE kun på /klagebehandlinger/{behandlingsid}/dokumenter. Greia var at jeg ville gjerne ha en annen response fra det "skinny" endepunktet, og da måtte jeg lage det på en egen URL. Men vi får se hva vi lander på, og så kan jeg endre og gjøre det mer harmonisert..