### PR TITLE
Lagt til endepunkt for kodeverk, for å hente ut kvalitetsvurdering og for å sette grunn

### DIFF
--- a/src/main/kotlin/no/nav/klage/oppgave/api/KlagebehandlingController.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/KlagebehandlingController.kt
@@ -1,14 +1,16 @@
 package no.nav.klage.oppgave.api
 
 import io.swagger.annotations.Api
+import no.nav.klage.oppgave.api.view.GrunnInput
 import no.nav.klage.oppgave.api.view.KlagebehandlingView
+import no.nav.klage.oppgave.api.view.KvalitetsvurderingView
 import no.nav.klage.oppgave.config.SecurityConfiguration.Companion.ISSUER_AAD
+import no.nav.klage.oppgave.domain.kodeverk.Grunn
+import no.nav.klage.oppgave.exceptions.ValidationException
 import no.nav.klage.oppgave.repositories.InnloggetSaksbehandlerRepository
 import no.nav.klage.oppgave.util.getLogger
 import no.nav.security.token.support.core.api.ProtectedWithClaims
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @Api(tags = ["klage-oppgave-api"])
@@ -28,11 +30,56 @@ class KlagebehandlingController(
         @PathVariable("id") oppgaveId: Long
     ): KlagebehandlingView {
         logger.debug(
+            "getKlagebehandling is requested by ident {} for klagebehandlingid {}",
+            innloggetSaksbehandlerRepository.getInnloggetIdent(),
+            oppgaveId
+        )
+        return klagebehandlingFacade.getKlagebehandling(oppgaveId)
+    }
+
+    @GetMapping("/oppgaver/{id}/klagebehandling/klage")
+    fun getKlagebehandlingByOppgave(
+        @PathVariable("id") oppgaveId: Long
+    ): KlagebehandlingView {
+        logger.debug(
             "getKlagebehandling is requested by ident {} for oppgaveId {}",
             innloggetSaksbehandlerRepository.getInnloggetIdent(),
             oppgaveId
         )
         return klagebehandlingFacade.getKlagebehandling(oppgaveId)
+    }
+
+    @GetMapping("/oppgaver/{id}/klagebehandling/kvalitetsvurdering")
+    fun getKvalitetsvurdering(
+        @PathVariable("id") oppgaveId: Long
+    ): KvalitetsvurderingView {
+        logger.debug(
+            "getKvalitetsvurdering is requested by ident {} for oppgaveId {}",
+            innloggetSaksbehandlerRepository.getInnloggetIdent(),
+            oppgaveId
+        )
+        return klagebehandlingFacade.getKvalitetsvurdering(oppgaveId)
+    }
+
+    @PutMapping("/oppgaver/{id}/klagebehandling/kvalitetsvurdering/grunn")
+    fun setGrunn(
+        @PathVariable("id") oppgaveId: Long,
+        @RequestBody input: GrunnInput
+    ): KvalitetsvurderingView {
+        logger.debug(
+            "getKvalitetsvurdering is requested by ident {} for oppgaveId {}",
+            innloggetSaksbehandlerRepository.getInnloggetIdent(),
+            oppgaveId
+        )
+        val grunn = parseAndValidateGrunn(input)
+        return klagebehandlingFacade.setKvalitetsvurderingGrunn(oppgaveId, grunn)
+    }
+
+    private fun parseAndValidateGrunn(input: GrunnInput) = try {
+        Grunn.of(input.grunn)
+    } catch (e: Exception) {
+        logger.error("${input.grunn} is not a valid Grunn")
+        throw ValidationException("${input.grunn} is not a valid Grunn")
     }
 
 }

--- a/src/main/kotlin/no/nav/klage/oppgave/api/KlagebehandlingFacade.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/KlagebehandlingFacade.kt
@@ -2,6 +2,8 @@ package no.nav.klage.oppgave.api
 
 import no.nav.klage.oppgave.api.mapper.KlagebehandlingMapper
 import no.nav.klage.oppgave.api.view.KlagebehandlingView
+import no.nav.klage.oppgave.api.view.KvalitetsvurderingView
+import no.nav.klage.oppgave.domain.kodeverk.Grunn
 import no.nav.klage.oppgave.service.KlagebehandlingService
 import no.nav.klage.oppgave.util.getLogger
 import no.nav.klage.oppgave.util.getSecureLogger
@@ -23,9 +25,19 @@ class KlagebehandlingFacade(
 
     fun getKlagebehandling(oppgaveId: Long): KlagebehandlingView {
         return klagebehandlingMapper.mapKlagebehandlingToKlagebehandlingView(
-            klagebehandlingService.getKlagebehandlingByOppgaveId(
-                oppgaveId
-            )
+            klagebehandlingService.getKlagebehandlingByOppgaveId(oppgaveId)
+        )
+    }
+
+    fun getKvalitetsvurdering(oppgaveId: Long): KvalitetsvurderingView {
+        return klagebehandlingMapper.mapKlagebehandlingToKvalitetsvurderingView(
+            klagebehandlingService.getKlagebehandlingByOppgaveId(oppgaveId)
+        )
+    }
+
+    fun setKvalitetsvurderingGrunn(oppgaveId: Long, grunn: Grunn): KvalitetsvurderingView {
+        return klagebehandlingMapper.mapKlagebehandlingToKvalitetsvurderingView(
+            klagebehandlingService.setKvalitetsvurderingGrunn(oppgaveId, grunn)
         )
     }
 }

--- a/src/main/kotlin/no/nav/klage/oppgave/api/KodeverkController.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/KodeverkController.kt
@@ -1,0 +1,20 @@
+package no.nav.klage.oppgave.api
+
+import no.nav.klage.oppgave.api.view.KodeverkResponse
+import no.nav.klage.oppgave.util.getLogger
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class KodeverkController {
+
+    companion object {
+        @Suppress("JAVA_CLASS_ON_COMPANION")
+        private val logger = getLogger(javaClass.enclosingClass)
+    }
+
+    @GetMapping("/kodeverk", produces = ["application/json"])
+    fun getKodeverk(): KodeverkResponse {
+        return KodeverkResponse()
+    }
+}

--- a/src/main/kotlin/no/nav/klage/oppgave/api/mapper/KlagebehandlingMapper.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/mapper/KlagebehandlingMapper.kt
@@ -2,6 +2,7 @@ package no.nav.klage.oppgave.api.mapper
 
 
 import no.nav.klage.oppgave.api.view.KlagebehandlingView
+import no.nav.klage.oppgave.api.view.KvalitetsvurderingView
 import no.nav.klage.oppgave.domain.klage.Hjemmel
 import no.nav.klage.oppgave.domain.klage.Klagebehandling
 import no.nav.klage.oppgave.service.OppgaveKopiService
@@ -21,7 +22,7 @@ class KlagebehandlingMapper(
     }
 
     fun mapKlagebehandlingToKlagebehandlingView(klagebehandling: Klagebehandling): KlagebehandlingView {
-        
+
         return KlagebehandlingView(
             id = klagebehandling.id,
             klageInnsendtdato = klagebehandling.innsendt,
@@ -52,5 +53,16 @@ class KlagebehandlingMapper(
                 original = it.original
             )
         }
+    }
+
+    fun mapKlagebehandlingToKvalitetsvurderingView(klagebehandling: Klagebehandling): KvalitetsvurderingView {
+        return KvalitetsvurderingView(
+            grunn = klagebehandling.kvalitetsvurdering?.grunn?.id,
+            eoes = klagebehandling.kvalitetsvurdering?.eoes?.id,
+            raadfoertMedLege = klagebehandling.kvalitetsvurdering?.raadfoertMedLege?.id,
+            internVurdering = klagebehandling.kvalitetsvurdering?.internVurdering,
+            sendTilbakemelding = klagebehandling.kvalitetsvurdering?.sendTilbakemelding,
+            tilbakemelding = klagebehandling.kvalitetsvurdering?.tilbakemelding
+        )
     }
 }

--- a/src/main/kotlin/no/nav/klage/oppgave/api/view/KodeverkResponse.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/view/KodeverkResponse.kt
@@ -1,0 +1,14 @@
+package no.nav.klage.oppgave.api.view
+
+import no.nav.klage.oppgave.domain.kodeverk.*
+
+data class KodeverkResponse(
+    val eoes: List<Eoes> = Eoes.values().asList(),
+    val grunn: List<Grunn> = Grunn.values().asList(),
+    val kilde: List<Kilde> = Kilde.values().asList(),
+    val lov: List<Lov> = Lov.values().asList(),
+    val raadfoertMedLege: List<RaadfoertMedLege> = RaadfoertMedLege.values().asList(),
+    val sakstype: List<Sakstype> = Sakstype.values().asList(),
+    val tema: List<Tema> = Tema.values().asList(),
+    val utfall: List<Utfall> = Utfall.values().asList()
+)

--- a/src/main/kotlin/no/nav/klage/oppgave/api/view/KvalitetsvurderingInput.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/view/KvalitetsvurderingInput.kt
@@ -1,0 +1,3 @@
+package no.nav.klage.oppgave.api.view
+
+data class GrunnInput(val grunn: Int)

--- a/src/main/kotlin/no/nav/klage/oppgave/api/view/KvalitetsvurderingView.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/view/KvalitetsvurderingView.kt
@@ -1,0 +1,10 @@
+package no.nav.klage.oppgave.api.view
+
+data class KvalitetsvurderingView(
+    val grunn: Int?,
+    val eoes: Int?,
+    val raadfoertMedLege: Int?,
+    val internVurdering: String?,
+    val sendTilbakemelding: Boolean?,
+    val tilbakemelding: String?
+)

--- a/src/main/kotlin/no/nav/klage/oppgave/domain/klage/Klagebehandling.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/domain/klage/Klagebehandling.kt
@@ -43,7 +43,7 @@ class Klagebehandling(
     val vedtak: Vedtak? = null,
     @OneToOne(cascade = [CascadeType.ALL], orphanRemoval = true)
     @JoinColumn(name = "kvalitetsvurdering_id", nullable = true)
-    val kvalitetsvurdering: Kvalitetsvurdering? = null,
+    var kvalitetsvurdering: Kvalitetsvurdering? = null,
     @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true)
     @JoinColumn(name = "klagebehandling_id", referencedColumnName = "id", nullable = false)
     val hjemler: MutableList<Hjemmel> = mutableListOf(),
@@ -80,5 +80,12 @@ class Klagebehandling(
 
     override fun hashCode(): Int {
         return id.hashCode()
+    }
+
+    fun getOrCreateKvalitetsvurdering(): Kvalitetsvurdering {
+        if (kvalitetsvurdering == null) {
+            kvalitetsvurdering = Kvalitetsvurdering()
+        }
+        return kvalitetsvurdering!!
     }
 }

--- a/src/main/kotlin/no/nav/klage/oppgave/domain/klage/Kvalitetsvurdering.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/domain/klage/Kvalitetsvurdering.kt
@@ -12,7 +12,7 @@ class Kvalitetsvurdering(
     val id: UUID = UUID.randomUUID(),
     @Column(name = "grunn_id")
     @Convert(converter = GrunnConverter::class)
-    val grunn: Grunn? = null,
+    var grunn: Grunn? = null,
     @Column(name = "eoes_id")
     @Convert(converter = EoesConverter::class)
     val eoes: Eoes? = null,
@@ -30,9 +30,9 @@ class Kvalitetsvurdering(
     @Column(name = "mottaker_enhet")
     val mottakerEnhet: String? = null,
     @Column(name = "created")
-    val created: LocalDateTime,
+    val created: LocalDateTime = LocalDateTime.now(),
     @Column(name = "modified")
-    val modified: LocalDateTime
+    val modified: LocalDateTime = LocalDateTime.now()
 ) {
     override fun toString(): String {
         return "Tilbakemelding(id=$id, " +

--- a/src/main/kotlin/no/nav/klage/oppgave/service/KlagebehandlingService.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/service/KlagebehandlingService.kt
@@ -3,12 +3,14 @@ package no.nav.klage.oppgave.service
 import no.nav.klage.oppgave.domain.klage.Klagebehandling
 import no.nav.klage.oppgave.domain.klage.Mottak
 import no.nav.klage.oppgave.domain.klage.Oppgavereferanse
+import no.nav.klage.oppgave.domain.kodeverk.Grunn
 import no.nav.klage.oppgave.domain.kodeverk.Kilde
 import no.nav.klage.oppgave.domain.kodeverk.Sakstype
 import no.nav.klage.oppgave.domain.kodeverk.Tema
 import no.nav.klage.oppgave.domain.oppgavekopi.IdentType
 import no.nav.klage.oppgave.domain.oppgavekopi.OppgaveKopiVersjon
 import no.nav.klage.oppgave.domain.oppgavekopi.VersjonIdent
+import no.nav.klage.oppgave.exceptions.KlagebehandlingNotFoundException
 import no.nav.klage.oppgave.repositories.KlagebehandlingRepository
 import no.nav.klage.oppgave.util.getLogger
 import org.springframework.stereotype.Service
@@ -25,12 +27,19 @@ class KlagebehandlingService(
     companion object {
         @Suppress("JAVA_CLASS_ON_COMPANION")
         private val logger = getLogger(javaClass.enclosingClass)
-        private val klageinstansPrefix = "42"
+        private const val klageinstansPrefix = "42"
     }
 
     fun getKlagebehandlingByOppgaveId(oppgaveId: Long): Klagebehandling {
         return klagebehandlingRepository.findByOppgavereferanserOppgaveId(oppgaveId)
-            ?: throw RuntimeException("klagebehandling not found")
+            ?: throw KlagebehandlingNotFoundException("klagebehandling not found")
+    }
+
+    fun setKvalitetsvurderingGrunn(oppgaveId: Long, grunn: Grunn): Klagebehandling {
+        val klagebehandling = getKlagebehandlingByOppgaveId(oppgaveId)
+        val kvalitetsvurdering = klagebehandling.getOrCreateKvalitetsvurdering()
+        kvalitetsvurdering.grunn = grunn
+        return klagebehandling
     }
 
     fun fetchKlagesakForOppgaveKopi(oppgaveId: Long): Klagebehandling? =
@@ -44,7 +53,7 @@ class KlagebehandlingService(
             requireNotNull(nyesteVersjon.ident)
             requireNotNull(nyesteVersjon.behandlingstype)
 
-            val mottak: Mottak = Mottak(
+            val mottak = Mottak(
                 tema = mapTema(nyesteVersjon.tema),
                 sakstype = mapSakstype(nyesteVersjon.behandlingstype),
                 referanseId = nyesteVersjon.saksreferanse,
@@ -115,5 +124,6 @@ class KlagebehandlingService(
 
     private fun findLastVersionWhereTildeltEnhetIsNotKAAndSaksbehandlerIsNotNull(oppgaveKopiVersjoner: List<OppgaveKopiVersjon>): OppgaveKopiVersjon? =
         oppgaveKopiVersjoner.firstOrNull { !it.tildeltEnhetsnr.startsWith(klageinstansPrefix) && it.tilordnetRessurs != null }
+
 
 }


### PR DESCRIPTION
- jeg returnerer IDen til enumene (grunn, rådførtMedLege mm), ikke en tekstlig verdi.
- jeg har også lagt til et kodeverk-endepunkt, som kan brukes til å hente ut alle gyldige verdier for de ulike enumene, med både og id navn.
- jeg har lagt til et GET-endepunkt for kvalitetsvurderingen og et PUT-endepunkt for grunn, ref det vi ble enig om i tråden over.
- jeg har også endret litt på eksisterende endepunkt (eller lagt til et nytt og tenkt at vi kan deprecate det gamle..), da det var misvisende å ha /klagebehandling/id/.. når det vi faktisk sendte inn var oppgaveId..