### PR TITLE
Harmonisere kode

### DIFF
--- a/src/main/kotlin/no/nav/klage/oppgave/api/KlagebehandlingFacade.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/KlagebehandlingFacade.kt
@@ -2,11 +2,8 @@ package no.nav.klage.oppgave.api
 
 import no.nav.klage.oppgave.api.mapper.KlagebehandlingMapper
 import no.nav.klage.oppgave.api.mapper.OppgaveMapper
-import no.nav.klage.oppgave.api.view.AntallUtgaatteFristerResponse
-import no.nav.klage.oppgave.api.view.KlagebehandlingView
-import no.nav.klage.oppgave.api.view.KvalitetsvurderingView
-import no.nav.klage.oppgave.api.view.OppgaverRespons
-import no.nav.klage.oppgave.domain.OppgaverSearchCriteria
+import no.nav.klage.oppgave.api.view.*
+import no.nav.klage.oppgave.domain.KlagebehandlingerSearchCriteria
 import no.nav.klage.oppgave.domain.klage.KvalitetsvurderingInput
 import no.nav.klage.oppgave.repositories.ElasticsearchRepository
 import no.nav.klage.oppgave.service.KlagebehandlingService
@@ -41,25 +38,36 @@ class KlagebehandlingFacade(
         )
     }
 
-    fun searchOppgaver(oppgaverSearchCriteria: OppgaverSearchCriteria): OppgaverRespons {
-        val esResponse = elasticsearchRepository.findByCriteria(oppgaverSearchCriteria)
-        return OppgaverRespons(
+    fun searchKlagebehandlinger(searchCriteria: KlagebehandlingerSearchCriteria): KlagebehandlingerListRespons {
+        val esResponse = elasticsearchRepository.findByCriteria(searchCriteria)
+        return KlagebehandlingerListRespons(
             antallTreffTotalt = esResponse.totalHits.toInt(),
-            oppgaver = oppgaveMapper.mapEsKlagebehandlingerToView(
+            klagebehandlinger = klagebehandlingMapper.mapEsKlagebehandlingerToListView(
                 esResponse.searchHits.map { it.content },
-                oppgaverSearchCriteria.isProjectionUtvidet()
+                searchCriteria.isProjectionUtvidet()
             )
         )
     }
 
-    fun countOppgaver(oppgaverSearchCriteria: OppgaverSearchCriteria): AntallUtgaatteFristerResponse {
-        return AntallUtgaatteFristerResponse(
-            antall = elasticsearchRepository.countByCriteria(oppgaverSearchCriteria)
+    fun searchOppgaver(klagebehandlingerSearchCriteria: KlagebehandlingerSearchCriteria): OppgaverRespons {
+        val esResponse = elasticsearchRepository.findByCriteria(klagebehandlingerSearchCriteria)
+        return OppgaverRespons(
+            antallTreffTotalt = esResponse.totalHits.toInt(),
+            oppgaver = oppgaveMapper.mapEsKlagebehandlingerToView(
+                esResponse.searchHits.map { it.content },
+                klagebehandlingerSearchCriteria.isProjectionUtvidet()
+            )
         )
     }
 
-    fun assignOppgave(klagebehandlingId: UUID, saksbehandlerIdent: String?) {
-        klagebehandlingService.assignOppgave(klagebehandlingId, saksbehandlerIdent)
+    fun countOppgaver(klagebehandlingerSearchCriteria: KlagebehandlingerSearchCriteria): AntallUtgaatteFristerResponse {
+        return AntallUtgaatteFristerResponse(
+            antall = elasticsearchRepository.countByCriteria(klagebehandlingerSearchCriteria)
+        )
+    }
+
+    fun assignKlagebehandling(klagebehandlingId: UUID, saksbehandlerIdent: String?) {
+        klagebehandlingService.assignKlagebehandling(klagebehandlingId, saksbehandlerIdent)
         val oppgaveIderForKlagebehandling = klagebehandlingService.getOppgaveIderForKlagebehandling(klagebehandlingId)
 
         oppgaveIderForKlagebehandling.forEach {

--- a/src/main/kotlin/no/nav/klage/oppgave/api/KlagebehandlingListController.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/KlagebehandlingListController.kt
@@ -3,7 +3,7 @@ package no.nav.klage.oppgave.api
 import io.swagger.annotations.Api
 import io.swagger.annotations.ApiOperation
 import io.swagger.annotations.ApiParam
-import no.nav.klage.oppgave.api.mapper.OppgaverQueryParamsMapper
+import no.nav.klage.oppgave.api.mapper.KlagebehandlingerQueryParamsMapper
 import no.nav.klage.oppgave.api.view.*
 import no.nav.klage.oppgave.config.SecurityConfiguration.Companion.ISSUER_AAD
 import no.nav.klage.oppgave.exceptions.BehandlingsidWrongFormatException
@@ -20,9 +20,9 @@ import java.util.*
 @RestController
 @Api(tags = ["klage-oppgave-api"])
 @ProtectedWithClaims(issuer = ISSUER_AAD)
-class OppgaveController(
+class KlagebehandlingListController(
     private val klagebehandlingFacade: KlagebehandlingFacade,
-    private val oppgaverQueryParamsMapper: OppgaverQueryParamsMapper,
+    private val klagebehandlingerQueryParamsMapper: KlagebehandlingerQueryParamsMapper,
     private val innloggetSaksbehandlerRepository: InnloggetSaksbehandlerRepository
 ) {
 
@@ -35,20 +35,20 @@ class OppgaveController(
         value = "Hent oppgaver for en ansatt",
         notes = "Henter alle oppgaver som saksbehandler har tilgang til."
     )
-    @GetMapping("/ansatte/{navIdent}/oppgaver", produces = ["application/json"])
+    @GetMapping("/ansatte/{navIdent}/klagebehandlinger", produces = ["application/json"])
     fun getOppgaver(
         @ApiParam(value = "NavIdent til en ansatt")
         @PathVariable navIdent: String,
-        queryParams: OppgaverQueryParams
-    ): OppgaverRespons {
+        queryParams: KlagebehandlingerQueryParams
+    ): KlagebehandlingerListRespons {
         logger.debug("Params: {}", queryParams)
         validateNavIdent(navIdent)
-        return klagebehandlingFacade.searchOppgaver(
-            oppgaverQueryParamsMapper.toSearchCriteria(navIdent, queryParams)
+        return klagebehandlingFacade.searchKlagebehandlinger(
+            klagebehandlingerQueryParamsMapper.toSearchCriteria(navIdent, queryParams)
         )
     }
 
-    @PostMapping("/ansatte/{navIdent}/oppgaver/{id}/saksbehandlertildeling")
+    @PostMapping("/ansatte/{navIdent}/klagebehandlinger/{id}/saksbehandlertildeling")
     fun assignSaksbehandler(
         @ApiParam(value = "NavIdent til en ansatt")
         @PathVariable navIdent: String,
@@ -68,13 +68,13 @@ class OppgaveController(
         return ResponseEntity.noContent().location(uri).build()
     }
 
-    @PostMapping("/ansatte/{navIdent}/oppgaver/{id}/saksbehandlerfradeling")
+    @PostMapping("/ansatte/{navIdent}/klagebehandlinger/{id}/saksbehandlerfradeling")
     fun unassignSaksbehandler(
         @ApiParam(value = "NavIdent til en ansatt")
         @PathVariable navIdent: String,
         @ApiParam(value = "Id til en klagebehandling")
         @PathVariable("id") klagebehandlingId: String,
-        @RequestBody saksbehandlerfradeling: Saksbehandlerfradeling
+        @RequestBody(required = false) saksbehandlerfradeling: Saksbehandlerfradeling?
     ): ResponseEntity<Void> {
         logger.debug("unassignSaksbehandler is requested for klagebehandling: {}", klagebehandlingId)
         klagebehandlingFacade.assignKlagebehandling(
@@ -96,12 +96,12 @@ class OppgaveController(
     fun getAntallUtgaatteFrister(
         @ApiParam(value = "NavIdent til en ansatt")
         @PathVariable navIdent: String,
-        queryParams: OppgaverQueryParams
+        queryParams: KlagebehandlingerQueryParams
     ): AntallUtgaatteFristerResponse {
         logger.debug("Params: {}", queryParams)
         validateNavIdent(navIdent)
         return klagebehandlingFacade.countOppgaver(
-            oppgaverQueryParamsMapper.toFristUtgaattIkkeTildeltSearchCriteria(navIdent, queryParams)
+            klagebehandlingerQueryParamsMapper.toFristUtgaattIkkeTildeltSearchCriteria(navIdent, queryParams)
         )
     }
 

--- a/src/main/kotlin/no/nav/klage/oppgave/api/OppgaveFacade.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/OppgaveFacade.kt
@@ -12,7 +12,7 @@ import org.springframework.stereotype.Service
 @Service
 class OppgaveFacade(
     private val oppgaveMapper: OppgaveMapper,
-    private val klagebehandlingMapper: KlagebehandlingMapper
+    private val klagebehandlingMapper: KlagebehandlingMapper,
     private val oppgaveKopiService: OppgaveKopiService,
     private val elasticsearchRepository: ElasticsearchRepository
 ) {

--- a/src/main/kotlin/no/nav/klage/oppgave/api/OppgaveFacade.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/OppgaveFacade.kt
@@ -1,6 +1,7 @@
 package no.nav.klage.oppgave.api
 
 import no.nav.klage.oppgave.api.internal.OppgaveKopiAPIModel
+import no.nav.klage.oppgave.api.mapper.KlagebehandlingMapper
 import no.nav.klage.oppgave.api.mapper.OppgaveMapper
 import no.nav.klage.oppgave.repositories.ElasticsearchRepository
 import no.nav.klage.oppgave.service.OppgaveKopiService
@@ -11,6 +12,7 @@ import org.springframework.stereotype.Service
 @Service
 class OppgaveFacade(
     private val oppgaveMapper: OppgaveMapper,
+    private val klagebehandlingMapper: KlagebehandlingMapper
     private val oppgaveKopiService: OppgaveKopiService,
     private val elasticsearchRepository: ElasticsearchRepository
 ) {
@@ -28,7 +30,7 @@ class OppgaveFacade(
         try {
             klagebehandlingerOgMottak.forEach {
                 elasticsearchRepository.save(
-                    oppgaveMapper.mapKlagebehandlingOgMottakToEsKlagebehandling(it)
+                    klagebehandlingMapper.mapKlagebehandlingOgMottakToEsKlagebehandling(it)
                 )
             }
         } catch (e: Exception) {

--- a/src/main/kotlin/no/nav/klage/oppgave/api/mapper/KlagebehandlingMapper.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/mapper/KlagebehandlingMapper.kt
@@ -1,8 +1,10 @@
 package no.nav.klage.oppgave.api.mapper
 
 
+import no.nav.klage.oppgave.api.view.KlagebehandlingListView
 import no.nav.klage.oppgave.api.view.KlagebehandlingView
 import no.nav.klage.oppgave.api.view.KvalitetsvurderingView
+import no.nav.klage.oppgave.domain.elasticsearch.EsKlagebehandling
 import no.nav.klage.oppgave.domain.klage.Hjemmel
 import no.nav.klage.oppgave.domain.klage.Klagebehandling
 import no.nav.klage.oppgave.util.getLogger
@@ -18,6 +20,31 @@ class KlagebehandlingMapper(
         @Suppress("JAVA_CLASS_ON_COMPANION")
         private val logger = getLogger(javaClass.enclosingClass)
         private val secureLogger = getSecureLogger()
+    }
+
+    fun mapEsKlagebehandlingerToListView(
+        esKlagebehandlinger: List<EsKlagebehandling>,
+        fetchPersoner: Boolean
+    ): List<KlagebehandlingListView> {
+        return esKlagebehandlinger.map { esKlagebehandling ->
+            KlagebehandlingListView(
+                id = esKlagebehandling.id,
+                person = if (fetchPersoner) {
+                    KlagebehandlingListView.Person(
+                        esKlagebehandling.foedselsnummer,
+                        esKlagebehandling.navn
+                    )
+                } else {
+                    null
+                },
+                type = esKlagebehandling.sakstype.id,
+                tema = esKlagebehandling.tema.id,
+                hjemmel = esKlagebehandling.hjemler?.firstOrNull(),
+                frist = esKlagebehandling.frist,
+                mottatt = esKlagebehandling.mottattKlageinstans,
+                versjon = esKlagebehandling.versjon!!.toInt()
+            )
+        }
     }
 
     fun mapKlagebehandlingToKlagebehandlingView(klagebehandling: Klagebehandling): KlagebehandlingView {

--- a/src/main/kotlin/no/nav/klage/oppgave/api/mapper/KlagebehandlingMapper.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/mapper/KlagebehandlingMapper.kt
@@ -4,22 +4,62 @@ package no.nav.klage.oppgave.api.mapper
 import no.nav.klage.oppgave.api.view.KlagebehandlingListView
 import no.nav.klage.oppgave.api.view.KlagebehandlingView
 import no.nav.klage.oppgave.api.view.KvalitetsvurderingView
+import no.nav.klage.oppgave.clients.egenansatt.EgenAnsattService
+import no.nav.klage.oppgave.clients.pdl.PdlFacade
 import no.nav.klage.oppgave.domain.elasticsearch.EsKlagebehandling
 import no.nav.klage.oppgave.domain.klage.Hjemmel
 import no.nav.klage.oppgave.domain.klage.Klagebehandling
+import no.nav.klage.oppgave.domain.klage.Mottak
 import no.nav.klage.oppgave.util.getLogger
 import no.nav.klage.oppgave.util.getSecureLogger
 import org.springframework.stereotype.Service
 
 @Service
 class KlagebehandlingMapper(
-
+    private val pdlFacade: PdlFacade,
+    private val egenAnsattService: EgenAnsattService
 ) {
 
     companion object {
         @Suppress("JAVA_CLASS_ON_COMPANION")
         private val logger = getLogger(javaClass.enclosingClass)
         private val secureLogger = getSecureLogger()
+    }
+
+    fun mapKlagebehandlingOgMottakToEsKlagebehandling(klagebehandlingOgMottak: Pair<Klagebehandling, Mottak>): EsKlagebehandling {
+
+        val klagebehandling = klagebehandlingOgMottak.first
+        //TODO: Nå bruker jeg ikke mottak her, så jeg kunne endret Pair<Klagebehandling, Mottak> til å bare være Klagebehandling?
+        //TODO: Er det noe vi skal indeksere opp som kommer fra Mottak? Beskrivelse f.eks?
+
+        val personInfo = klagebehandling.foedselsnummer?.let { pdlFacade.getPersonInfo(it) }
+        val erFortrolig = personInfo?.harBeskyttelsesbehovFortrolig() ?: false
+        val erStrengtFortrolig = personInfo?.harBeskyttelsesbehovStrengtFortrolig() ?: false
+        val erEgenAnsatt = klagebehandling.foedselsnummer?.let { egenAnsattService.erEgenAnsatt(it) } ?: false
+        val navn = personInfo?.navn
+
+        return EsKlagebehandling(
+            id = klagebehandling.id.toString(),
+            versjon = klagebehandling.versjon,
+            journalpostId = klagebehandling.saksdokumenter.map { it.referanse },
+            saksreferanse = klagebehandling.referanseId,
+            tildeltEnhet = klagebehandling.tildeltEnhet,
+            tema = klagebehandling.tema,
+            sakstype = klagebehandling.sakstype,
+            tildeltSaksbehandlerident = klagebehandling.tildeltSaksbehandlerident,
+            innsendt = klagebehandling.innsendt,
+            mottattFoersteinstans = klagebehandling.mottattFoersteinstans,
+            mottattKlageinstans = klagebehandling.mottattKlageinstans,
+            frist = klagebehandling.frist,
+            startet = klagebehandling.startet,
+            avsluttet = klagebehandling.avsluttet,
+            hjemler = klagebehandling.hjemler.map { it.original },
+            foedselsnummer = klagebehandling.foedselsnummer,
+            navn = navn,
+            egenAnsatt = erEgenAnsatt,
+            fortrolig = erFortrolig,
+            strengtFortrolig = erStrengtFortrolig
+        )
     }
 
     fun mapEsKlagebehandlingerToListView(
@@ -59,7 +99,7 @@ class KlagebehandlingMapper(
             fraNAVEnhet = klagebehandling.avsenderEnhetFoersteinstans,
             fraSaksbehandlerident = klagebehandling.avsenderSaksbehandleridentFoersteinstans,
             mottattFoersteinstans = klagebehandling.mottattFoersteinstans,
-            foedselsnummer = klagebehandling.foedselsnummer ?: "mangler",
+            foedselsnummer = klagebehandling.foedselsnummer,
             tema = klagebehandling.tema.id,
             sakstype = klagebehandling.sakstype.navn,
             mottatt = klagebehandling.mottattKlageinstans,

--- a/src/main/kotlin/no/nav/klage/oppgave/api/mapper/KlagebehandlingerQueryParamsMapper.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/mapper/KlagebehandlingerQueryParamsMapper.kt
@@ -1,6 +1,6 @@
 package no.nav.klage.oppgave.api.mapper
 
-import no.nav.klage.oppgave.api.view.OppgaverQueryParams
+import no.nav.klage.oppgave.api.view.KlagebehandlingerQueryParams
 import no.nav.klage.oppgave.domain.KlagebehandlingerSearchCriteria
 import no.nav.klage.oppgave.domain.kodeverk.Sakstype
 import no.nav.klage.oppgave.domain.kodeverk.Tema
@@ -11,18 +11,18 @@ import org.springframework.stereotype.Service
 import java.time.LocalDate
 
 @Service
-class OppgaverQueryParamsMapper(private val saksbehandlerRepository: SaksbehandlerRepository) {
+class KlagebehandlingerQueryParamsMapper(private val saksbehandlerRepository: SaksbehandlerRepository) {
 
     companion object {
         @Suppress("JAVA_CLASS_ON_COMPANION")
         private val logger = getLogger(javaClass.enclosingClass)
     }
 
-    fun toSearchCriteria(navIdent: String, queryParams: OppgaverQueryParams) = KlagebehandlingerSearchCriteria(
-        typer = queryParams.typer.map { Sakstype.fromNavn(it) },
-        temaer = queryParams.temaer.map { Tema.fromNavn(it) },
+    fun toSearchCriteria(navIdent: String, queryParams: KlagebehandlingerQueryParams) = KlagebehandlingerSearchCriteria(
+        typer = queryParams.typer.map { Sakstype.of(it) },
+        temaer = queryParams.temaer.map { Tema.of(it) },
         hjemler = queryParams.hjemler,
-        order = if (queryParams.rekkefoelge == OppgaverQueryParams.Rekkefoelge.SYNKENDE) {
+        order = if (queryParams.rekkefoelge == KlagebehandlingerQueryParams.Rekkefoelge.SYNKENDE) {
             KlagebehandlingerSearchCriteria.Order.DESC
         } else {
             KlagebehandlingerSearchCriteria.Order.ASC
@@ -33,22 +33,22 @@ class OppgaverQueryParamsMapper(private val saksbehandlerRepository: Saksbehandl
         saksbehandler = queryParams.tildeltSaksbehandler,
         projection = queryParams.projeksjon?.let { KlagebehandlingerSearchCriteria.Projection.valueOf(it.name) },
         enhetsnr = validateAndGetEnhetId(navIdent, queryParams.enhetId),
-        sortField = if (queryParams.sortering == OppgaverQueryParams.Sortering.MOTTATT) {
+        sortField = if (queryParams.sortering == KlagebehandlingerQueryParams.Sortering.MOTTATT) {
             KlagebehandlingerSearchCriteria.SortField.MOTTATT
         } else {
             KlagebehandlingerSearchCriteria.SortField.FRIST
         }
     )
 
-    fun toFristUtgaattIkkeTildeltSearchCriteria(navIdent: String, oppgaverQueryParams: OppgaverQueryParams) =
+    fun toFristUtgaattIkkeTildeltSearchCriteria(navIdent: String, queryParams: KlagebehandlingerQueryParams) =
         KlagebehandlingerSearchCriteria(
-            typer = oppgaverQueryParams.typer.map { Sakstype.fromNavn(it) },
-            temaer = oppgaverQueryParams.temaer.map { Tema.fromNavn(it) },
-            hjemler = oppgaverQueryParams.hjemler,
+            typer = queryParams.typer.map { Sakstype.of(it) },
+            temaer = queryParams.temaer.map { Tema.of(it) },
+            hjemler = queryParams.hjemler,
             offset = 0,
             limit = 1,
             erTildeltSaksbehandler = false,
-            enhetsnr = validateAndGetEnhetId(navIdent, oppgaverQueryParams.enhetId),
+            enhetsnr = validateAndGetEnhetId(navIdent, queryParams.enhetId),
             fristFom = LocalDate.now().minusYears(15),
             fristTom = LocalDate.now().minusDays(1),
         )

--- a/src/main/kotlin/no/nav/klage/oppgave/api/mapper/OppgaveMapper.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/mapper/OppgaveMapper.kt
@@ -5,8 +5,6 @@ import no.nav.klage.oppgave.api.internal.OppgaveKopiAPIModel
 import no.nav.klage.oppgave.clients.egenansatt.EgenAnsattService
 import no.nav.klage.oppgave.clients.pdl.PdlFacade
 import no.nav.klage.oppgave.domain.elasticsearch.EsKlagebehandling
-import no.nav.klage.oppgave.domain.klage.Klagebehandling
-import no.nav.klage.oppgave.domain.klage.Mottak
 import no.nav.klage.oppgave.domain.oppgavekopi.*
 import no.nav.klage.oppgave.util.getLogger
 import no.nav.klage.oppgave.util.getSecureLogger
@@ -88,42 +86,6 @@ class OppgaveMapper(
             metadata = oppgave.metadata?.map { (k, v) ->
                 MetadataNoekkel.valueOf(k.name) to v
             }?.toMap() ?: emptyMap()
-        )
-    }
-
-    fun mapKlagebehandlingOgMottakToEsKlagebehandling(klagebehandlingOgMottak: Pair<Klagebehandling, Mottak>): EsKlagebehandling {
-
-        val klagebehandling = klagebehandlingOgMottak.first
-        //TODO: Nå bruker jeg ikke mottak her, så jeg kunne endret Pair<Klagebehandling, Mottak> til å bare være Klagebehandling?
-        //TODO: Er det noe vi skal indeksere opp som kommer fra Mottak? Beskrivelse f.eks?
-
-        val personInfo = klagebehandling.foedselsnummer?.let { pdlFacade.getPersonInfo(it) }
-        val erFortrolig = personInfo?.harBeskyttelsesbehovFortrolig() ?: false
-        val erStrengtFortrolig = personInfo?.harBeskyttelsesbehovStrengtFortrolig() ?: false
-        val erEgenAnsatt = klagebehandling.foedselsnummer?.let { egenAnsattService.erEgenAnsatt(it) } ?: false
-        val navn = personInfo?.navn ?: "mangler navn"
-
-        return EsKlagebehandling(
-            id = klagebehandling.id.toString(),
-            versjon = klagebehandling.versjon,
-            journalpostId = klagebehandling.saksdokumenter.map { it.referanse },
-            saksreferanse = klagebehandling.referanseId,
-            tildeltEnhet = klagebehandling.tildeltEnhet,
-            tema = klagebehandling.tema,
-            sakstype = klagebehandling.sakstype,
-            tildeltSaksbehandlerident = klagebehandling.tildeltSaksbehandlerident,
-            innsendt = klagebehandling.innsendt,
-            mottattFoersteinstans = klagebehandling.mottattFoersteinstans,
-            mottattKlageinstans = klagebehandling.mottattKlageinstans,
-            frist = klagebehandling.frist,
-            startet = klagebehandling.startet,
-            avsluttet = klagebehandling.avsluttet,
-            hjemler = klagebehandling.hjemler.map { it.original },
-            foedselsnummer = klagebehandling.foedselsnummer,
-            navn = navn,
-            egenAnsatt = erEgenAnsatt,
-            fortrolig = erFortrolig,
-            strengtFortrolig = erStrengtFortrolig
         )
     }
 }

--- a/src/main/kotlin/no/nav/klage/oppgave/api/view/KlagebehandlingListView.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/view/KlagebehandlingListView.kt
@@ -1,0 +1,24 @@
+package no.nav.klage.oppgave.api.view
+
+import java.time.LocalDate
+
+data class KlagebehandlingerListRespons(
+    val antallTreffTotalt: Int,
+    val klagebehandlinger: List<KlagebehandlingListView>
+)
+
+data class KlagebehandlingListView(
+    val id: String,
+    val person: Person? = null,
+    val type: String,
+    val tema: String,
+    val hjemmel: String?,
+    val frist: LocalDate?,
+    val mottatt: LocalDate?,
+    val versjon: Int
+) {
+    data class Person(
+        val fnr: String?,
+        val navn: String?
+    )
+}

--- a/src/main/kotlin/no/nav/klage/oppgave/api/view/KlagebehandlingView.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/view/KlagebehandlingView.kt
@@ -9,7 +9,7 @@ data class KlagebehandlingView(
     val klageInnsendtdato: LocalDate?,
     val fraNAVEnhet: String?,
     val mottattFoersteinstans: LocalDate? = null,
-    val foedselsnummer: String,
+    val foedselsnummer: String?,
     val tema: String,
     val sakstype: String,
     val mottatt: LocalDate,

--- a/src/main/kotlin/no/nav/klage/oppgave/api/view/KlagebehandlingerQueryParams.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/view/KlagebehandlingerQueryParams.kt
@@ -1,0 +1,28 @@
+package no.nav.klage.oppgave.api.view
+
+data class KlagebehandlingerQueryParams(
+    var typer: List<String> = emptyList(),
+    var temaer: List<String> = emptyList(),
+    var hjemler: List<String> = emptyList(),
+    val rekkefoelge: Rekkefoelge? = Rekkefoelge.STIGENDE,
+    val sortering: Sortering? = Sortering.FRIST,
+    val start: Int,
+    val antall: Int,
+    val projeksjon: Projeksjon? = null,
+    val erTildeltSaksbehandler: Boolean? = null,
+    val tildeltSaksbehandler: String? = null,
+    val enhetId: String
+) {
+
+    enum class Rekkefoelge {
+        STIGENDE, SYNKENDE
+    }
+
+    enum class Sortering {
+        FRIST, MOTTATT
+    }
+
+    enum class Projeksjon {
+        UTVIDET
+    }
+}

--- a/src/main/kotlin/no/nav/klage/oppgave/api/view/Saksbehandlertildeling.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/view/Saksbehandlertildeling.kt
@@ -2,9 +2,9 @@ package no.nav.klage.oppgave.api.view
 
 data class Saksbehandlertildeling(
     val navIdent: String,
-    val oppgaveversjon: String
+    val oppgaveversjon: String?
 )
 
 data class Saksbehandlerfradeling(
-    val oppgaveversjon: String
+    val oppgaveversjon: String?
 )

--- a/src/main/kotlin/no/nav/klage/oppgave/clients/gosys/OppgaveClient.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/clients/gosys/OppgaveClient.kt
@@ -3,7 +3,7 @@ package no.nav.klage.oppgave.clients.gosys
 import brave.Tracer
 import no.nav.klage.oppgave.domain.BEHANDLINGSTYPE_FEILUTBETALING
 import no.nav.klage.oppgave.domain.BEHANDLINGSTYPE_KLAGE
-import no.nav.klage.oppgave.domain.OppgaverSearchCriteria
+import no.nav.klage.oppgave.domain.KlagebehandlingerSearchCriteria
 import no.nav.klage.oppgave.domain.kodeverk.Sakstype
 import no.nav.klage.oppgave.exceptions.OppgaveNotFoundException
 import no.nav.klage.oppgave.service.TokenService
@@ -39,7 +39,7 @@ class OppgaveClient(
     }
 
     @Retryable
-    fun getOppgaveCount(oppgaveSearchCriteria: OppgaverSearchCriteria): Int {
+    fun getOppgaveCount(oppgaveSearchCriteria: KlagebehandlingerSearchCriteria): Int {
         return logTimingAndWebClientResponseException("getOneSearchPage") {
             oppgaveWebClient.get()
                 .uri { uriBuilder -> oppgaveSearchCriteria.buildUri(uriBuilder) }
@@ -53,7 +53,7 @@ class OppgaveClient(
     }
 
     @Retryable
-    fun getOneSearchPage(oppgaveSearchCriteria: OppgaverSearchCriteria): OppgaveResponse {
+    fun getOneSearchPage(oppgaveSearchCriteria: KlagebehandlingerSearchCriteria): OppgaveResponse {
         return logTimingAndWebClientResponseException("getOneSearchPage") {
             oppgaveWebClient.get()
                 .uri { uriBuilder -> oppgaveSearchCriteria.buildUri(uriBuilder) }
@@ -66,7 +66,7 @@ class OppgaveClient(
         }
     }
 
-    private fun OppgaverSearchCriteria.buildUri(origUriBuilder: UriBuilder): URI {
+    private fun KlagebehandlingerSearchCriteria.buildUri(origUriBuilder: UriBuilder): URI {
         logger.debug("Search criteria: {}", this)
         val uriBuilder = origUriBuilder
             .queryParam("statuskategori", statuskategori)
@@ -119,7 +119,7 @@ class OppgaveClient(
 
         //FRIST is default in oppgave-api.
 //        uriBuilder.queryParam("sorteringsfelt", orderBy ?: "frist")
-        uriBuilder.queryParam("sorteringsrekkefolge", order ?: OppgaverSearchCriteria.Order.ASC)
+        uriBuilder.queryParam("sorteringsrekkefolge", order ?: KlagebehandlingerSearchCriteria.Order.ASC)
 
         if (hjemler.isNotEmpty()) {
             uriBuilder.queryParam("metadatanokkel", HJEMMEL)

--- a/src/main/kotlin/no/nav/klage/oppgave/clients/pdl/Person.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/clients/pdl/Person.kt
@@ -2,10 +2,10 @@ package no.nav.klage.oppgave.clients.pdl
 
 data class Person(
     val foedselsnr: String,
-    val fornavn: String,
+    val fornavn: String?,
     val mellomnavn: String?,
-    val etternavn: String,
-    val navn: String,
+    val etternavn: String?,
+    val navn: String?,
     val beskyttelsesbehov: Beskyttelsesbehov?
 ) {
     fun harBeskyttelsesbehovFortrolig() = beskyttelsesbehov == Beskyttelsesbehov.FORTROLIG

--- a/src/main/kotlin/no/nav/klage/oppgave/clients/pdl/graphql/HentPersonMapper.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/clients/pdl/graphql/HentPersonMapper.kt
@@ -20,11 +20,11 @@ class HentPersonMapper {
         secureLogger.debug("pdl returned {}", pdlPerson)
         return Person(
             foedselsnr = fnr,
-            fornavn = pdlPerson.navn.firstOrNull()?.fornavn ?: "mangler",
+            fornavn = pdlPerson.navn.firstOrNull()?.fornavn,
             mellomnavn = pdlPerson.navn.firstOrNull()?.mellomnavn,
-            etternavn = pdlPerson.navn.firstOrNull()?.etternavn ?: "mangler",
+            etternavn = pdlPerson.navn.firstOrNull()?.etternavn,
             navn = sammensattNavn(pdlPerson.navn.firstOrNull()),
-            beskyttelsesbehov = pdlPerson.adressebeskyttelse?.firstOrNull()?.gradering?.mapToBeskyttelsesbehov()
+            beskyttelsesbehov = pdlPerson.adressebeskyttelse.firstOrNull()?.gradering?.mapToBeskyttelsesbehov()
         )
     }
 
@@ -36,21 +36,17 @@ class HentPersonMapper {
         return people.map {
             Person(
                 foedselsnr = it.ident,
-                fornavn = it.person?.navn?.firstOrNull()?.fornavn ?: "mangler",
+                fornavn = it.person?.navn?.firstOrNull()?.fornavn,
                 mellomnavn = it.person?.navn?.firstOrNull()?.mellomnavn,
-                etternavn = it.person?.navn?.firstOrNull()?.etternavn ?: "mangler",
+                etternavn = it.person?.navn?.firstOrNull()?.etternavn,
                 navn = sammensattNavn(it.person?.navn?.firstOrNull()),
                 beskyttelsesbehov = it.person?.adressebeskyttelse?.firstOrNull()?.gradering?.mapToBeskyttelsesbehov()
             )
         }
     }
 
-    private fun sammensattNavn(navn: PdlPerson.Navn?): String =
-        if (navn == null) {
-            "mangler navn"
-        } else {
-            "${navn.fornavn} ${navn.etternavn}"
-        }
+    private fun sammensattNavn(navn: PdlPerson.Navn?): String? =
+        navn?.let { "${it.fornavn} ${it.etternavn}" }
 
     fun PdlPerson.Adressebeskyttelse.GraderingType.mapToBeskyttelsesbehov(): Beskyttelsesbehov? =
         when (this) {

--- a/src/main/kotlin/no/nav/klage/oppgave/domain/KlagebehandlingerSearchCriteria.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/domain/KlagebehandlingerSearchCriteria.kt
@@ -5,7 +5,7 @@ import no.nav.klage.oppgave.domain.kodeverk.Tema
 import java.time.LocalDate
 import java.time.LocalDateTime
 
-data class OppgaverSearchCriteria(
+data class KlagebehandlingerSearchCriteria(
     val typer: List<Sakstype> = emptyList(),
     val temaer: List<Tema> = emptyList(),
     val hjemler: List<String> = emptyList(),

--- a/src/main/kotlin/no/nav/klage/oppgave/repositories/ElasticsearchRepository.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/repositories/ElasticsearchRepository.kt
@@ -1,6 +1,6 @@
 package no.nav.klage.oppgave.repositories
 
-import no.nav.klage.oppgave.domain.OppgaverSearchCriteria
+import no.nav.klage.oppgave.domain.KlagebehandlingerSearchCriteria
 import no.nav.klage.oppgave.domain.elasticsearch.EsKlagebehandling
 import no.nav.klage.oppgave.domain.kodeverk.Sakstype
 import no.nav.klage.oppgave.util.getLogger
@@ -65,7 +65,7 @@ open class ElasticsearchRepository(
         esTemplate.save(klagebehandling)
     }
 
-    open fun findByCriteria(criteria: OppgaverSearchCriteria): SearchHits<EsKlagebehandling> {
+    open fun findByCriteria(criteria: KlagebehandlingerSearchCriteria): SearchHits<EsKlagebehandling> {
         val query: Query = NativeSearchQueryBuilder()
             .withPageable(toPageable(criteria))
             .withSort(SortBuilders.fieldSort(sortField(criteria)).order(mapOrder(criteria.order)))
@@ -76,37 +76,37 @@ open class ElasticsearchRepository(
         return searchHits
     }
 
-    open fun countByCriteria(criteria: OppgaverSearchCriteria): Int {
+    open fun countByCriteria(criteria: KlagebehandlingerSearchCriteria): Int {
         val query = NativeSearchQueryBuilder()
             .withQuery(criteria.toEsQuery())
             .build()
         return esTemplate.count(query, IndexCoordinates.of("klagebehandling")).toInt()
     }
 
-    private fun sortField(criteria: OppgaverSearchCriteria): String =
-        if (criteria.sortField == OppgaverSearchCriteria.SortField.MOTTATT) {
+    private fun sortField(criteria: KlagebehandlingerSearchCriteria): String =
+        if (criteria.sortField == KlagebehandlingerSearchCriteria.SortField.MOTTATT) {
             "mottattKlageinstans"
         } else {
             "frist"
         }
 
-    private fun mapOrder(order: OppgaverSearchCriteria.Order?): SortOrder {
+    private fun mapOrder(order: KlagebehandlingerSearchCriteria.Order?): SortOrder {
         return order.let {
             when (it) {
                 null -> SortOrder.ASC
-                OppgaverSearchCriteria.Order.ASC -> SortOrder.ASC
-                OppgaverSearchCriteria.Order.DESC -> SortOrder.DESC
+                KlagebehandlingerSearchCriteria.Order.ASC -> SortOrder.ASC
+                KlagebehandlingerSearchCriteria.Order.DESC -> SortOrder.DESC
             }
         }
     }
 
-    private fun toPageable(criteria: OppgaverSearchCriteria): Pageable {
+    private fun toPageable(criteria: KlagebehandlingerSearchCriteria): Pageable {
         val page: Int = (criteria.offset / criteria.limit)
         val size: Int = criteria.limit
         return PageRequest.of(page, size)
     }
 
-    private fun OppgaverSearchCriteria.toEsQuery(): QueryBuilder {
+    private fun KlagebehandlingerSearchCriteria.toEsQuery(): QueryBuilder {
 
         val baseQuery: BoolQueryBuilder = QueryBuilders.boolQuery()
         logger.debug("Search criteria: {}", this)
@@ -124,7 +124,7 @@ open class ElasticsearchRepository(
             filterQuery.mustNot(QueryBuilders.termQuery("strengtFortrolig", true))
         }
 
-        if (statuskategori == OppgaverSearchCriteria.Statuskategori.AAPEN) {
+        if (statuskategori == KlagebehandlingerSearchCriteria.Statuskategori.AAPEN) {
             baseQuery.mustNot(QueryBuilders.existsQuery("avsluttet"))
         } else {
             baseQuery.must(QueryBuilders.existsQuery("avsluttet"))

--- a/src/main/kotlin/no/nav/klage/oppgave/service/KlagebehandlingService.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/service/KlagebehandlingService.kt
@@ -203,7 +203,7 @@ class KlagebehandlingService(
             }
             ?.first
 
-    fun assignOppgave(klagebehandlingId: UUID, saksbehandlerIdent: String?) {
+    fun assignKlagebehandling(klagebehandlingId: UUID, saksbehandlerIdent: String?) {
         val klagebehandling = getKlagebehandling(klagebehandlingId)
         klagebehandling.tildeltSaksbehandlerident = saksbehandlerIdent
         klagebehandling.modified = LocalDateTime.now()

--- a/src/main/kotlin/no/nav/klage/oppgave/service/OppgaveStatistikkService.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/service/OppgaveStatistikkService.kt
@@ -1,7 +1,7 @@
 package no.nav.klage.oppgave.service
 
 import no.nav.klage.oppgave.clients.gosys.OppgaveClient
-import no.nav.klage.oppgave.domain.OppgaverSearchCriteria
+import no.nav.klage.oppgave.domain.KlagebehandlingerSearchCriteria
 import no.nav.klage.oppgave.domain.kodeverk.Sakstype
 import no.nav.klage.oppgave.domain.kodeverk.Tema
 import no.nav.klage.oppgave.util.getLogger
@@ -21,10 +21,10 @@ class OppgaveStatistikkService(
     }
 
     fun ubehandledeKlager(): Int {
-        val searchCriteria = OppgaverSearchCriteria(
+        val searchCriteria = KlagebehandlingerSearchCriteria(
             typer = listOf(Sakstype.KLAGE),
             temaer = listOf(Tema.SYK),
-            statuskategori = OppgaverSearchCriteria.Statuskategori.AAPEN,
+            statuskategori = KlagebehandlingerSearchCriteria.Statuskategori.AAPEN,
             offset = 0,
             limit = 1
         )
@@ -32,10 +32,10 @@ class OppgaveStatistikkService(
     }
 
     fun klagerOverFrist(): Int {
-        val searchCriteria = OppgaverSearchCriteria(
+        val searchCriteria = KlagebehandlingerSearchCriteria(
             typer = listOf(Sakstype.KLAGE),
             temaer = listOf(Tema.SYK),
-            statuskategori = OppgaverSearchCriteria.Statuskategori.AAPEN,
+            statuskategori = KlagebehandlingerSearchCriteria.Statuskategori.AAPEN,
             fristFom = LocalDate.now().plusDays(1),
             offset = 0,
             limit = 1
@@ -47,19 +47,19 @@ class OppgaveStatistikkService(
         val startOfPeriod = startOfPeriod(numberOfDays)
         val endOfPeriod = endOfPeriod(numberOfDays)
 
-        val searchCriteria1 = OppgaverSearchCriteria(
+        val searchCriteria1 = KlagebehandlingerSearchCriteria(
             typer = listOf(Sakstype.KLAGE),
             temaer = listOf(Tema.SYK),
-            statuskategori = OppgaverSearchCriteria.Statuskategori.AAPEN,
+            statuskategori = KlagebehandlingerSearchCriteria.Statuskategori.AAPEN,
             opprettetFom = startOfPeriod,
             opprettetTom = endOfPeriod,
             offset = 0,
             limit = 1
         )
-        val searchCriteria2 = OppgaverSearchCriteria(
+        val searchCriteria2 = KlagebehandlingerSearchCriteria(
             typer = listOf(Sakstype.KLAGE),
             temaer = listOf(Tema.SYK),
-            statuskategori = OppgaverSearchCriteria.Statuskategori.AVSLUTTET,
+            statuskategori = KlagebehandlingerSearchCriteria.Statuskategori.AVSLUTTET,
             opprettetFom = startOfPeriod,
             opprettetTom = endOfPeriod,
             offset = 0,
@@ -72,10 +72,10 @@ class OppgaveStatistikkService(
         val startOfPeriod = startOfPeriod(numberOfDays)
         val endOfPeriod = endOfPeriod(numberOfDays)
 
-        val searchCriteria = OppgaverSearchCriteria(
+        val searchCriteria = KlagebehandlingerSearchCriteria(
             typer = listOf(Sakstype.KLAGE),
             temaer = listOf(Tema.SYK),
-            statuskategori = OppgaverSearchCriteria.Statuskategori.AVSLUTTET,
+            statuskategori = KlagebehandlingerSearchCriteria.Statuskategori.AVSLUTTET,
             ferdigstiltFom = startOfPeriod,
             ferdigstiltTom = endOfPeriod,
             offset = 0,

--- a/src/test/kotlin/no/nav/klage/oppgave/clients/OppgaveClientTest.kt
+++ b/src/test/kotlin/no/nav/klage/oppgave/clients/OppgaveClientTest.kt
@@ -7,7 +7,7 @@ import io.mockk.junit5.MockKExtension
 import no.nav.klage.oppgave.clients.gosys.Oppgave
 import no.nav.klage.oppgave.clients.gosys.OppgaveClient
 import no.nav.klage.oppgave.clients.gosys.OppgaveResponse
-import no.nav.klage.oppgave.domain.OppgaverSearchCriteria
+import no.nav.klage.oppgave.domain.KlagebehandlingerSearchCriteria
 import no.nav.klage.oppgave.service.TokenService
 import org.assertj.core.api.Assertions.assertThat
 import org.intellij.lang.annotations.Language
@@ -72,7 +72,7 @@ internal class OppgaveClientTest {
         )
 
         return oppgaveClient.getOneSearchPage(
-            OppgaverSearchCriteria(
+            KlagebehandlingerSearchCriteria(
                 offset = 0,
                 limit = 1
             )

--- a/src/test/kotlin/no/nav/klage/oppgave/service/ElasticsearchRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/klage/oppgave/service/ElasticsearchRepositoryTest.kt
@@ -2,7 +2,7 @@ package no.nav.klage.oppgave.service
 
 import com.ninjasquad.springmockk.MockkBean
 import no.nav.klage.oppgave.config.ElasticsearchServiceConfiguration
-import no.nav.klage.oppgave.domain.OppgaverSearchCriteria
+import no.nav.klage.oppgave.domain.KlagebehandlingerSearchCriteria
 import no.nav.klage.oppgave.domain.elasticsearch.EsKlagebehandling
 import no.nav.klage.oppgave.domain.kodeverk.Sakstype
 import no.nav.klage.oppgave.domain.kodeverk.Tema
@@ -135,7 +135,7 @@ class ElasticsearchRepositoryTest {
     fun `Klagebehandling can be searched for by tema`() {
         val klagebehandlinger: List<EsKlagebehandling> =
             repository.findByCriteria(
-                OppgaverSearchCriteria(
+                KlagebehandlingerSearchCriteria(
                     temaer = listOf(Tema.SYK),
                     offset = 0,
                     limit = 10
@@ -150,7 +150,7 @@ class ElasticsearchRepositoryTest {
     fun `Klagebehandling can be searched for by frist`() {
         val klagebehandlinger: List<EsKlagebehandling> =
             repository.findByCriteria(
-                OppgaverSearchCriteria(
+                KlagebehandlingerSearchCriteria(
                     fristFom = LocalDate.of(2020, 12, 1),
                     offset = 0,
                     limit = 10


### PR DESCRIPTION
Lagt til KlagebehandlingListController som en erstatning for OppgaveController. Den bruker IDen til enums for sakstype og tema, ikke navnet. Så frontend må slå opp kodene fra KodeverkController for å kunne vise navnet. Har også renamet en del fra oppgave til klagebehandling nedover i koden.

Har også endret så vi ikke stapper inn "mangler" der vi ikke finner navn eller fnr, men i stedet har blanke felt. Hva som vises i gui bør ikke bestemmes i backend. 