### PR TITLE
Forslag til håndtering av lazy loading i JPA

### DIFF
--- a/src/main/kotlin/no/nav/klage/oppgave/api/KlagebehandlingFacade.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/KlagebehandlingFacade.kt
@@ -12,7 +12,6 @@ import no.nav.klage.oppgave.service.OppgaveService
 import no.nav.klage.oppgave.util.getLogger
 import no.nav.klage.oppgave.util.getSecureLogger
 import org.springframework.stereotype.Service
-import org.springframework.transaction.annotation.Transactional
 import java.util.*
 
 @Service
@@ -30,7 +29,6 @@ class KlagebehandlingFacade(
         private val securelogger = getSecureLogger()
     }
 
-    @Transactional(readOnly = true)
     fun getKlagebehandling(klagebehandlingId: UUID): KlagebehandlingView {
         return klagebehandlingMapper.mapKlagebehandlingToKlagebehandlingView(
             klagebehandlingService.getKlagebehandling(
@@ -67,7 +65,6 @@ class KlagebehandlingFacade(
         )
     }
 
-    @Transactional
     fun assignKlagebehandling(klagebehandlingId: UUID, saksbehandlerIdent: String?) {
         klagebehandlingService.assignKlagebehandling(klagebehandlingId, saksbehandlerIdent)
             .also { indexKlagebehandling(it) }
@@ -88,21 +85,19 @@ class KlagebehandlingFacade(
         }
     }
 
-    @Transactional(readOnly = true)
     fun getKvalitetsvurdering(klagebehandlingId: UUID): KvalitetsvurderingView {
         return klagebehandlingMapper.mapKlagebehandlingToKvalitetsvurderingView(
-            klagebehandlingService.getKlagebehandling(klagebehandlingId)
+            klagebehandlingService.getKvalitetsvurdering(klagebehandlingId)
         )
     }
 
-    @Transactional
     fun updateKvalitetsvurdering(
         klagebehandlingId: UUID,
         kvalitetsvurderingInput: KvalitetsvurderingInput
     ): KvalitetsvurderingView {
         return klagebehandlingMapper.mapKlagebehandlingToKvalitetsvurderingView(
             klagebehandlingService.updateKvalitetsvurdering(klagebehandlingId, kvalitetsvurderingInput)
-                .also { indexKlagebehandling(it) }
+                .also { indexKlagebehandling(it) }.kvalitetsvurdering
         )
     }
 

--- a/src/main/kotlin/no/nav/klage/oppgave/api/mapper/KlagebehandlingMapper.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/api/mapper/KlagebehandlingMapper.kt
@@ -9,6 +9,7 @@ import no.nav.klage.oppgave.clients.pdl.PdlFacade
 import no.nav.klage.oppgave.domain.elasticsearch.EsKlagebehandling
 import no.nav.klage.oppgave.domain.klage.Hjemmel
 import no.nav.klage.oppgave.domain.klage.Klagebehandling
+import no.nav.klage.oppgave.domain.klage.Kvalitetsvurdering
 import no.nav.klage.oppgave.util.getLogger
 import no.nav.klage.oppgave.util.getSecureLogger
 import org.springframework.stereotype.Service
@@ -26,7 +27,7 @@ class KlagebehandlingMapper(
     }
 
     fun mapKlagebehandlingOgMottakToEsKlagebehandling(klagebehandling: Klagebehandling): EsKlagebehandling {
-        
+
         val personInfo = klagebehandling.foedselsnummer?.let { pdlFacade.getPersonInfo(it) }
         val erFortrolig = personInfo?.harBeskyttelsesbehovFortrolig() ?: false
         val erStrengtFortrolig = personInfo?.harBeskyttelsesbehovStrengtFortrolig() ?: false
@@ -108,7 +109,7 @@ class KlagebehandlingMapper(
         )
     }
 
-    private fun hjemmelToHjemmelView(hjemler: List<Hjemmel>): List<KlagebehandlingView.Hjemmel> {
+    private fun hjemmelToHjemmelView(hjemler: Set<Hjemmel>): List<KlagebehandlingView.Hjemmel> {
         return hjemler.map {
             KlagebehandlingView.Hjemmel(
                 kapittel = it.kapittel,
@@ -117,17 +118,17 @@ class KlagebehandlingMapper(
                 bokstav = it.bokstav,
                 original = it.original
             )
-        }
+        }.sortedBy { it.original }
     }
 
-    fun mapKlagebehandlingToKvalitetsvurderingView(klagebehandling: Klagebehandling): KvalitetsvurderingView {
+    fun mapKlagebehandlingToKvalitetsvurderingView(kvalitetsvurdering: Kvalitetsvurdering?): KvalitetsvurderingView {
         return KvalitetsvurderingView(
-            grunn = klagebehandling.kvalitetsvurdering?.grunn?.id,
-            eoes = klagebehandling.kvalitetsvurdering?.eoes?.id,
-            raadfoertMedLege = klagebehandling.kvalitetsvurdering?.raadfoertMedLege?.id,
-            internVurdering = klagebehandling.kvalitetsvurdering?.internVurdering,
-            sendTilbakemelding = klagebehandling.kvalitetsvurdering?.sendTilbakemelding,
-            tilbakemelding = klagebehandling.kvalitetsvurdering?.tilbakemelding
+            grunn = kvalitetsvurdering?.grunn?.id,
+            eoes = kvalitetsvurdering?.eoes?.id,
+            raadfoertMedLege = kvalitetsvurdering?.raadfoertMedLege?.id,
+            internVurdering = kvalitetsvurdering?.internVurdering,
+            sendTilbakemelding = kvalitetsvurdering?.sendTilbakemelding,
+            tilbakemelding = kvalitetsvurdering?.tilbakemelding
         )
     }
 }

--- a/src/main/kotlin/no/nav/klage/oppgave/domain/klage/Klagebehandling.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/domain/klage/Klagebehandling.kt
@@ -54,10 +54,10 @@ class Klagebehandling(
     @OneToOne(cascade = [CascadeType.ALL], orphanRemoval = true)
     @JoinColumn(name = "kvalitetsvurdering_id", nullable = true)
     var kvalitetsvurdering: Kvalitetsvurdering? = null,
-    @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true)
+    @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.EAGER)
     @JoinColumn(name = "klagebehandling_id", referencedColumnName = "id", nullable = false)
-    val hjemler: MutableList<Hjemmel> = mutableListOf(),
-    @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true)
+    val hjemler: MutableSet<Hjemmel> = mutableSetOf(),
+    @OneToMany(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.EAGER)
     @JoinColumn(name = "klagebehandling_id", referencedColumnName = "id", nullable = false)
     val saksdokumenter: MutableList<Saksdokument> = mutableListOf(),
     @Column(name = "created")

--- a/src/main/kotlin/no/nav/klage/oppgave/service/KlagebehandlingService.kt
+++ b/src/main/kotlin/no/nav/klage/oppgave/service/KlagebehandlingService.kt
@@ -43,6 +43,9 @@ class KlagebehandlingService(
     fun getKlagebehandling(klagebehandlingId: UUID): Klagebehandling =
         klagebehandlingRepository.getOne(klagebehandlingId).also { checkTilgang(it) }
 
+    fun getKvalitetsvurdering(klagebehandlingId: UUID): Kvalitetsvurdering? =
+        klagebehandlingRepository.getOne(klagebehandlingId).also { checkTilgang(it) }.kvalitetsvurdering
+
     fun fetchMottakForOppgaveKopi(oppgaveId: Long): List<Mottak> =
         mottakRepository.findByOppgavereferanserOppgaveId(oppgaveId)
 
@@ -132,7 +135,7 @@ class KlagebehandlingService(
                 mottakId = createdMottak.id,
                 vedtak = null,
                 kvalitetsvurdering = null,
-                hjemler = createdMottak.hjemler().map { hjemmelService.generateHjemmelFromText(it) }.toMutableList(),
+                hjemler = createdMottak.hjemler().map { hjemmelService.generateHjemmelFromText(it) }.toMutableSet(),
                 saksdokumenter = if (createdMottak.journalpostId != null) {
                     mutableListOf(Saksdokument(referanse = createdMottak.journalpostId!!))
                 } else {

--- a/src/test/kotlin/no/nav/klage/oppgave/repositories/KlagebehandlingRepositoryTest.kt
+++ b/src/test/kotlin/no/nav/klage/oppgave/repositories/KlagebehandlingRepositoryTest.kt
@@ -51,7 +51,7 @@ class KlagebehandlingRepositoryTest {
             tema = Tema.SYK,
             sakstype = Sakstype.KLAGE,
             frist = LocalDate.now(),
-            hjemler = mutableListOf(
+            hjemler = mutableSetOf(
                 Hjemmel(
                     original = "8-5"
                 )
@@ -107,7 +107,7 @@ class KlagebehandlingRepositoryTest {
             tema = Tema.SYK,
             sakstype = Sakstype.KLAGE,
             frist = LocalDate.now(),
-            hjemler = mutableListOf(
+            hjemler = mutableSetOf(
                 Hjemmel(
                     original = "8-5"
                 )
@@ -145,7 +145,7 @@ class KlagebehandlingRepositoryTest {
         val foundklage = klagebehandlingRepository.findById(klage.id).get()
         assertThat(foundklage.vedtak?.utfall).isEqualTo(Utfall.DELVIS_MEDHOLD)
         assertThat(foundklage.kvalitetsvurdering?.raadfoertMedLege).isEqualTo(RaadfoertMedLege.MANGLER)
-        assertThat(foundklage.hjemler[0].original).isEqualTo("8-5")
+        assertThat(foundklage.hjemler.first().original).isEqualTo("8-5")
     }
 
     @Test
@@ -167,7 +167,7 @@ class KlagebehandlingRepositoryTest {
             tema = Tema.SYK,
             sakstype = Sakstype.KLAGE,
             frist = LocalDate.now(),
-            hjemler = mutableListOf(
+            hjemler = mutableSetOf(
                 Hjemmel(
                     original = "8-5"
                 )
@@ -213,7 +213,7 @@ class KlagebehandlingRepositoryTest {
             tema = Tema.SYK,
             sakstype = Sakstype.KLAGE,
             frist = LocalDate.now(),
-            hjemler = mutableListOf(
+            hjemler = mutableSetOf(
                 Hjemmel(
                     original = "8-5"
                 )


### PR DESCRIPTION
Gjort hjemler om til et set, og gjort hjemler og saksdokumenter eager fetched. Slipper da lazyloading feil på dem. Kvalitetsvurdering brukes bare i sidene for kvalitetsvurdering, så jeg initialiserer dem inni transaksjonen før de sendes ut